### PR TITLE
Update positions of multiple objects in SampleScene

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1219,7 +1219,7 @@ Transform:
   m_GameObject: {fileID: 358912366}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 118.5, y: 15.5, z: 0}
+  m_LocalPosition: {x: 233.5, y: 6.9, z: 0}
   m_LocalScale: {x: 9.909375, y: 7.6792183, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1805,7 +1805,7 @@ Transform:
   m_GameObject: {fileID: 451783661}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 115.4, y: 7.8, z: 0}
+  m_LocalPosition: {x: -6.1341, y: -1.8, z: 0}
   m_LocalScale: {x: 0.23986, y: 0.23986, z: 0.23986}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2105,7 +2105,7 @@ Transform:
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 116.89055, y: 7.4672003, z: -1}
+  m_LocalPosition: {x: -4.643551, y: -2.1327999, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -44788,7 +44788,7 @@ Transform:
   m_GameObject: {fileID: 2061402347}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 116.89055, y: 7.4672003, z: -1}
+  m_LocalPosition: {x: -4.643551, y: -2.1327999, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
Adjusted the m_LocalPosition values for several objects in SampleScene.unity to new coordinates. This likely reflects changes to the scene layout or object placement within the Unity editor.