### PR TITLE
Enable Canvas camera and increment sorting order

### DIFF
--- a/Assets/API testing.meta
+++ b/Assets/API testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2b3022a6bb1ca64bb4c2b5215f1dc2d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -4715,8 +4715,8 @@ Canvas:
   m_GameObject: {fileID: 1084599816}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
+  m_RenderMode: 1
+  m_Camera: {fileID: 519420031}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -4727,7 +4727,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &1084599820
 RectTransform:


### PR DESCRIPTION
Add meta for 'Assets/API testing' folder. Modify SampleScene.unity Canvas to use Screen Space - Camera (m_RenderMode set to 1), assign a camera (m_Camera fileID updated), and increase m_SortingOrder from 0 to 1 so the UI is rendered by the scene camera with adjusted ordering.