### PR TITLE
Add Unity MCP skill docs and BossLevel assets

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "enabledMcpjsonServers": [
+    "ai-game-developer"
+  ],
+  "enableAllProjectMcpServers": true
+}

--- a/.claude/skills/animation-create/SKILL.md
+++ b/.claude/skills/animation-create/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: animation-create
+description: Create Unity's Animation asset files (AnimationClip). Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.anim'.
+---
+
+# Animation / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-create --input '{
+  "sourcePaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the animation assets to create. Each path should start with 'Assets/' and end with '.anim'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreateAnimationResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreateAnimationResponse": {
+      "type": "object",
+      "properties": {
+        "createdAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo>"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/animation-get-data/SKILL.md
+++ b/.claude/skills/animation-get-data/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: animation-get-data
+description: Get data about a Unity AnimationClip asset file. Returns information such as name, length, frame rate, wrap mode, animation curves, and events.
+---
+
+# Animation / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-get-data --input '{
+  "animRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animRef` | `any` | Yes | Reference to the animation asset. The path should start with 'Assets/' and end with '.anim'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "animRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+GetDataResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "isPPtrCurve": {
+          "type": "boolean"
+        },
+        "isDiscreteCurve": {
+          "type": "boolean"
+        },
+        "keyframeCount": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "isPPtrCurve",
+        "isDiscreteCurve",
+        "keyframeCount"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo": {
+      "type": "object",
+      "properties": {
+        "time": {
+          "type": "number"
+        },
+        "functionName": {
+          "type": "string"
+        },
+        "intParameter": {
+          "type": "integer"
+        },
+        "floatParameter": {
+          "type": "number"
+        },
+        "stringParameter": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "time",
+        "intParameter",
+        "floatParameter"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+GetDataResponse": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number"
+        },
+        "frameRate": {
+          "type": "number"
+        },
+        "wrapMode": {
+          "type": "string"
+        },
+        "isLooping": {
+          "type": "boolean"
+        },
+        "hasGenericRootTransform": {
+          "type": "boolean"
+        },
+        "hasMotionCurves": {
+          "type": "boolean"
+        },
+        "hasMotionFloatCurves": {
+          "type": "boolean"
+        },
+        "hasRootCurves": {
+          "type": "boolean"
+        },
+        "humanMotion": {
+          "type": "boolean"
+        },
+        "legacy": {
+          "type": "boolean"
+        },
+        "localBounds": {
+          "type": "string"
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "curveBindings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>"
+        },
+        "objectReferenceBindings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>"
+        },
+        "events": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo>"
+        }
+      },
+      "required": [
+        "length",
+        "frameRate",
+        "isLooping",
+        "hasGenericRootTransform",
+        "hasMotionCurves",
+        "hasMotionFloatCurves",
+        "hasRootCurves",
+        "humanMotion",
+        "legacy",
+        "empty"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/animation-modify/SKILL.md
+++ b/.claude/skills/animation-modify/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: animation-modify
+description: Modify Unity's AnimationClip asset. Apply an array of modifications including setting curves, clearing curves, setting properties, and managing animation events. Use 'animation-get-data' tool to get valid property names and existing curves for modifications.
+---
+
+# Animation / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-modify --input '{
+  "animRef": "string_value",
+  "modifications": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animRef` | `any` | Yes | Reference to the AnimationClip asset to modify. |
+| `modifications` | `any` | Yes | Array of modifications to apply to the clip. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "modifications": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationModification[]"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationModification": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "SetCurve",
+            "RemoveCurve",
+            "ClearCurves",
+            "SetFrameRate",
+            "SetWrapMode",
+            "SetLegacy",
+            "AddEvent",
+            "ClearEvents"
+          ],
+          "description": "Modification type. Properties below are used conditionally based on this value."
+        },
+        "relativePath": {
+          "type": "string",
+          "description": "Path to target GameObject relative to the root (empty for root). Used by: SetCurve, RemoveCurve."
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Component type name (e.g., 'Transform', 'SpriteRenderer'). Required for: SetCurve, RemoveCurve."
+        },
+        "propertyName": {
+          "type": "string",
+          "description": "Property to animate (e.g., 'localPosition.x', 'm_LocalScale.y'). Required for: SetCurve, RemoveCurve."
+        },
+        "keyframes": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe[]",
+          "description": "Keyframes for the curve. Required for: SetCurve."
+        },
+        "frameRate": {
+          "type": "number",
+          "description": "Frames per second. Required for: SetFrameRate."
+        },
+        "wrapMode": {
+          "type": "string",
+          "enum": [
+            "Default",
+            "Clamp",
+            "Clamp",
+            "Loop",
+            "PingPong",
+            "ClampForever"
+          ],
+          "description": "How animation behaves at boundaries. Required for: SetWrapMode."
+        },
+        "legacy": {
+          "type": "boolean",
+          "description": "Use legacy animation system. Required for: SetLegacy."
+        },
+        "time": {
+          "type": "number",
+          "description": "Event trigger time in seconds. Required for: AddEvent."
+        },
+        "functionName": {
+          "type": "string",
+          "description": "Function to invoke. Required for: AddEvent."
+        },
+        "stringParameter": {
+          "type": "string",
+          "description": "String parameter passed to the function. Optional for: AddEvent."
+        },
+        "floatParameter": {
+          "type": "number",
+          "description": "Float parameter passed to the function. Optional for: AddEvent."
+        },
+        "intParameter": {
+          "type": "integer",
+          "description": "Integer parameter passed to the function. Optional for: AddEvent."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe": {
+      "type": "object",
+      "properties": {
+        "time": {
+          "type": "number",
+          "description": "Time in seconds."
+        },
+        "value": {
+          "type": "number",
+          "description": "Value at this keyframe."
+        },
+        "inTangent": {
+          "type": "number",
+          "description": "Incoming tangent (slope). Default: 0."
+        },
+        "outTangent": {
+          "type": "number",
+          "description": "Outgoing tangent (slope). Default: 0."
+        },
+        "weightedMode": {
+          "type": "string",
+          "enum": [
+            "None",
+            "In",
+            "Out",
+            "Both"
+          ],
+          "description": "Weighted mode: None (0), In (1), Out (2), Both (3). Default: None."
+        },
+        "inWeight": {
+          "type": "number",
+          "description": "Incoming weight. Default: 0.33."
+        },
+        "outWeight": {
+          "type": "number",
+          "description": "Outgoing weight. Default: 0.33."
+        }
+      },
+      "required": [
+        "time",
+        "value"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationModification[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationModification"
+      }
+    }
+  },
+  "required": [
+    "animRef",
+    "modifications"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationResponse": {
+      "type": "object",
+      "properties": {
+        "modifiedAsset": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationInfo"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/animator-create/SKILL.md
+++ b/.claude/skills/animator-create/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: animator-create
+description: Create Unity's AnimatorController asset files. Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.controller'.
+---
+
+# Animator / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-create --input '{
+  "sourcePaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the animator controller assets to create. Each path should start with 'Assets/' and end with '.controller'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreateAnimatorResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreateAnimatorResponse": {
+      "type": "object",
+      "properties": {
+        "createdAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo>"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/animator-get-data/SKILL.md
+++ b/.claude/skills/animator-get-data/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: animator-get-data
+description: Get data about a Unity AnimatorController asset file. Returns information such as name, layers, parameters, and states.
+---
+
+# Animator / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-get-data --input '{
+  "animatorRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animatorRef` | `any` | Yes | Reference to the AnimatorController asset. The path should start with 'Assets/' and end with '.controller'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animatorRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "animatorRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+GetAnimatorDataResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "defaultFloat": {
+          "type": "number"
+        },
+        "defaultInt": {
+          "type": "integer"
+        },
+        "defaultBool": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "defaultFloat",
+        "defaultInt",
+        "defaultBool"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "defaultWeight": {
+          "type": "number"
+        },
+        "blendingMode": {
+          "type": "string"
+        },
+        "syncedLayerIndex": {
+          "type": "integer"
+        },
+        "iKPass": {
+          "type": "boolean"
+        },
+        "defaultStateName": {
+          "type": "string"
+        },
+        "states": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo>"
+        },
+        "subStateMachines": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        },
+        "anyStateTransitions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>"
+        }
+      },
+      "required": [
+        "defaultWeight",
+        "syncedLayerIndex",
+        "iKPass"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "speed": {
+          "type": "number"
+        },
+        "speedParameterActive": {
+          "type": "boolean"
+        },
+        "speedParameter": {
+          "type": "string"
+        },
+        "cycleOffset": {
+          "type": "number"
+        },
+        "cycleOffsetParameterActive": {
+          "type": "boolean"
+        },
+        "cycleOffsetParameter": {
+          "type": "string"
+        },
+        "mirror": {
+          "type": "boolean"
+        },
+        "mirrorParameterActive": {
+          "type": "boolean"
+        },
+        "mirrorParameter": {
+          "type": "string"
+        },
+        "writeDefaultValues": {
+          "type": "boolean"
+        },
+        "motionName": {
+          "type": "string"
+        },
+        "transitions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>"
+        }
+      },
+      "required": [
+        "speed",
+        "speedParameterActive",
+        "cycleOffset",
+        "cycleOffsetParameterActive",
+        "mirror",
+        "mirrorParameterActive",
+        "writeDefaultValues"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo": {
+      "type": "object",
+      "properties": {
+        "destinationStateName": {
+          "type": "string"
+        },
+        "hasExitTime": {
+          "type": "boolean"
+        },
+        "exitTime": {
+          "type": "number"
+        },
+        "hasFixedDuration": {
+          "type": "boolean"
+        },
+        "duration": {
+          "type": "number"
+        },
+        "offset": {
+          "type": "number"
+        },
+        "canTransitionToSelf": {
+          "type": "boolean"
+        },
+        "conditions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo>"
+        }
+      },
+      "required": [
+        "hasExitTime",
+        "exitTime",
+        "hasFixedDuration",
+        "duration",
+        "offset",
+        "canTransitionToSelf"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo": {
+      "type": "object",
+      "properties": {
+        "parameter": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "threshold"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+GetAnimatorDataResponse": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo>"
+        },
+        "layers": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/animator-modify/SKILL.md
+++ b/.claude/skills/animator-modify/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: animator-modify
+description: Modify Unity's AnimatorController asset. Apply an array of modifications including adding/removing parameters, layers, states, and transitions. Use 'animator-get-data' tool to get valid names and parameters for modifications.
+---
+
+# Animator / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-modify --input '{
+  "animatorRef": "string_value",
+  "modifications": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animatorRef` | `any` | Yes | Reference to the AnimatorController asset to modify. |
+| `modifications` | `any` | Yes | Array of modifications to apply to the controller. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animatorRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "modifications": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorModification[]"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorModification": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AddParameter",
+            "RemoveParameter",
+            "AddLayer",
+            "RemoveLayer",
+            "AddState",
+            "RemoveState",
+            "SetDefaultState",
+            "AddTransition",
+            "RemoveTransition",
+            "AddAnyStateTransition",
+            "SetStateMotion",
+            "SetStateSpeed"
+          ],
+          "description": "Modification type. Properties below are used conditionally based on this value."
+        },
+        "parameterName": {
+          "type": "string",
+          "description": "Parameter name. Required for: AddParameter, RemoveParameter."
+        },
+        "parameterType": {
+          "type": "string",
+          "description": "Parameter type: Float, Int, Bool, Trigger. Required for: AddParameter."
+        },
+        "defaultFloat": {
+          "type": "number",
+          "description": "Default float value. Optional for: AddParameter (Float type)."
+        },
+        "defaultInt": {
+          "type": "integer",
+          "description": "Default int value. Optional for: AddParameter (Int type)."
+        },
+        "defaultBool": {
+          "type": "boolean",
+          "description": "Default bool value. Optional for: AddParameter (Bool type)."
+        },
+        "layerName": {
+          "type": "string",
+          "description": "Layer name. Required for: AddLayer, RemoveLayer, AddState, RemoveState, SetDefaultState, AddTransition, RemoveTransition, AddAnyStateTransition, SetStateMotion, SetStateSpeed."
+        },
+        "stateName": {
+          "type": "string",
+          "description": "State name. Required for: AddState, RemoveState, SetDefaultState, SetStateMotion, SetStateSpeed."
+        },
+        "motionAssetPath": {
+          "type": "string",
+          "description": "Asset path to AnimationClip. Optional for: AddState. Required for: SetStateMotion."
+        },
+        "speed": {
+          "type": "number",
+          "description": "Speed multiplier. Required for: SetStateSpeed."
+        },
+        "sourceStateName": {
+          "type": "string",
+          "description": "Source state name. Required for: AddTransition, RemoveTransition."
+        },
+        "destinationStateName": {
+          "type": "string",
+          "description": "Destination state name. Required for: AddTransition, RemoveTransition, AddAnyStateTransition."
+        },
+        "hasExitTime": {
+          "type": "boolean",
+          "description": "Whether transition waits for exit time. Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "exitTime": {
+          "type": "number",
+          "description": "Normalized exit time (0-1). Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "duration": {
+          "type": "number",
+          "description": "Transition blend duration. Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "hasFixedDuration": {
+          "type": "boolean",
+          "description": "Whether duration is in seconds (true) or normalized (false). Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "conditions": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData[]",
+          "description": "Transition conditions. Optional for: AddTransition, AddAnyStateTransition."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData": {
+      "type": "object",
+      "properties": {
+        "parameter": {
+          "type": "string",
+          "description": "Parameter name for the condition."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Condition mode: If, IfNot, Greater, Less, Equals, NotEqual."
+        },
+        "threshold": {
+          "type": "number",
+          "description": "Threshold value for the condition."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorModification[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorModification"
+      }
+    }
+  },
+  "required": [
+    "animatorRef",
+    "modifications"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+ModifyAnimatorResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Animation.ModifyAnimatorInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+ModifyAnimatorResponse": {
+      "type": "object",
+      "properties": {
+        "modifiedAsset": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.ModifyAnimatorInfo"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-copy/SKILL.md
+++ b/.claude/skills/assets-copy/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: assets-copy
+description: Copy assets at given paths and store them at new paths. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before copying.
+---
+
+# Assets / Copy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-copy --input '{
+  "sourcePaths": "string_value",
+  "destinationPaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-copy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-copy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the assets to copy. |
+| `destinationPaths` | `any` | Yes | The paths to store the copied assets. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "destinationPaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths",
+    "destinationPaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CopyAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CopyAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "CopiedAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>",
+          "description": "List of copied assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during copy operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-create-folder/SKILL.md
+++ b/.claude/skills/assets-create-folder/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: assets-create-folder
+description: Creates a new folder in the specified parent folder. The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end. Returns the GUID of the newly created folder, if successful.
+---
+
+# Assets / Create Folder
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-create-folder --input '{
+  "inputs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-create-folder --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-create-folder --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `inputs` | `any` | Yes | The paths for the folders to create. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "inputs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput": {
+      "type": "object",
+      "properties": {
+        "ParentFolderPath": {
+          "type": "string",
+          "description": "The parent folder path where the new folder will be created."
+        },
+        "NewFolderName": {
+          "type": "string",
+          "description": "The name of the new folder to create."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput"
+      }
+    }
+  },
+  "required": [
+    "inputs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderResponse": {
+      "type": "object",
+      "properties": {
+        "CreatedFolderGuids": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of GUIDs of created folders."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during folder creation."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-delete/SKILL.md
+++ b/.claude/skills/assets-delete/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: assets-delete
+description: Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before deleting.
+---
+
+# Assets / Delete
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-delete --input '{
+  "paths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-delete --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-delete --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `paths` | `any` | Yes | The paths of the assets |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "paths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "paths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+DeleteAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+DeleteAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "DeletedPaths": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of paths of deleted assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during delete operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-find-built-in/SKILL.md
+++ b/.claude/skills/assets-find-built-in/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: assets-find-built-in
+description: "Search the built-in assets of the Unity Editor located in the built-in resources: Resources/unity_builtin_extra. Doesn't support GUIDs since built-in assets do not have them."
+---
+
+# Assets / Find (Built-in)
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-find-built-in --input '{
+  "name": "string_value",
+  "type": "string_value",
+  "maxResults": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-find-built-in --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-find-built-in --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | No | The name of the asset to filter by. |
+| `type` | `any` | No | The type of the asset to filter by. |
+| `maxResults` | `integer` | No | Maximum number of assets to return. If the number of found assets exceeds this limit, the result will be truncated. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "$ref": "#/$defs/System.Type"
+    },
+    "maxResults": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-find/SKILL.md
+++ b/.claude/skills/assets-find/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: assets-find
+description: Search the asset database using the search filter string. Allows you to search for Assets. The string argument can provide names, labels or types (classnames).
+---
+
+# Assets / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-find --input '{
+  "filter": "string_value",
+  "searchInFolders": "string_value",
+  "maxResults": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `string` | No | The filter string can contain search data. Could be empty. Name: Filter assets by their filename (without extension). Words separated by whitespace are treated as separate name searches. Labels (l:): Assets can have labels attached to them. Use 'l:' before each label. Types (t:): Find assets based on explicitly identified types. Use 't:' keyword. Available types: AnimationClip, AudioClip, AudioMixer, ComputeShader, Font, GUISkin, Material, Mesh, Model, PhysicMaterial, Prefab, Scene, Script, Shader, Sprite, Texture, VideoClip, VisualEffectAsset, VisualEffectSubgraph. AssetBundles (b:): Find assets which are part of an Asset bundle. Area (a:): Find assets in a specific area. Valid values are 'all', 'assets', and 'packages'. Globbing (glob:): Use globbing to match specific rules. Note: Searching is case insensitive. |
+| `searchInFolders` | `any` | No | The folders where the search will start. If null, the search will be performed in all folders. |
+| `maxResults` | `integer` | No | Maximum number of assets to return. If the number of found assets exceeds this limit, the result will be truncated. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "type": "string"
+    },
+    "searchInFolders": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "maxResults": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-get-data/SKILL.md
+++ b/.claude/skills/assets-get-data/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: assets-get-data
+description: Get asset data from the asset file in the Unity project. It includes all serializable fields and properties of the asset. Use 'assets-find' tool to find asset before using this tool.
+---
+
+# Assets / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-get-data --input '{
+  "assetRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "assetRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-material-create/SKILL.md
+++ b/.claude/skills/assets-material-create/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: assets-material-create
+description: Create new material asset with default parameters. Creates folders recursively if they do not exist. Provide proper 'shaderName' - use 'assets-shader-list-all' tool to find available shaders.
+---
+
+# Assets / Create Material
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-material-create --input '{
+  "assetPath": "string_value",
+  "shaderName": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-material-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-material-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetPath` | `string` | Yes | Asset path. Starts with 'Assets/'. Ends with '.mat'. |
+| `shaderName` | `string` | Yes | Name of the shader that need to be used to create the material. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetPath": {
+      "type": "string"
+    },
+    "shaderName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "assetPath",
+    "shaderName"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-modify/SKILL.md
+++ b/.claude/skills/assets-modify/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: assets-modify
+description: Modify asset file in the project. Use 'assets-get-data' tool first to inspect the asset structure before modifying. Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.
+---
+
+# Assets / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-modify --input '{
+  "assetRef": "string_value",
+  "content": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `content` | `any` | Yes | The asset content. It overrides the existing asset content. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "content": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "assetRef",
+    "content"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-move/SKILL.md
+++ b/.claude/skills/assets-move/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: assets-move
+description: Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before moving.
+---
+
+# Assets / Move
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-move --input '{
+  "sourcePaths": "string_value",
+  "destinationPaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-move --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-move --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the assets to move. |
+| `destinationPaths` | `any` | Yes | The paths of moved assets. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "destinationPaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths",
+    "destinationPaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+MoveAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+MoveAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "MovedPaths": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of destination paths of successfully moved assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during move operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-prefab-close/SKILL.md
+++ b/.claude/skills/assets-prefab-close/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assets-prefab-close
+description: Close currently opened prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+---
+
+# Assets / Prefab / Close
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-close --input '{
+  "save": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-close --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-close --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `save` | `boolean` | No | True to save prefab. False to discard changes. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "save": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-prefab-create/SKILL.md
+++ b/.claude/skills/assets-prefab-create/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: assets-prefab-create
+description: Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Creates folders recursively if they do not exist. If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. Use 'gameobject-find' tool to find the target GameObject first.
+---
+
+# Assets / Prefab / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-create --input '{
+  "prefabAssetPath": "string_value",
+  "gameObjectRef": "string_value",
+  "sourcePrefabAssetPath": "string_value",
+  "connectGameObjectToPrefab": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefabAssetPath` | `string` | Yes | Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'. |
+| `gameObjectRef` | `any` | No | Reference to a scene GameObject to create the prefab from. If the GameObject is already a prefab instance, a Prefab Variant is created when 'connectGameObjectToPrefab' is true. Optional if 'sourcePrefabAssetPath' is provided. |
+| `sourcePrefabAssetPath` | `string` | No | Path to an existing prefab asset to create a Prefab Variant from (e.g. 'Assets/Prefabs/Base.prefab'). When provided, a temporary instance is created, saved as a Prefab Variant, and cleaned up. Optional if 'gameObjectRef' is provided. |
+| `connectGameObjectToPrefab` | `boolean` | No | If true, the scene GameObject will be connected to the new prefab (becoming a prefab instance). If the source is already a prefab instance, this creates a Prefab Variant. If false, the prefab asset is created but the scene GameObject remains unchanged. Ignored when 'sourcePrefabAssetPath' is used (always creates a variant). |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "prefabAssetPath": {
+      "type": "string"
+    },
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "sourcePrefabAssetPath": {
+      "type": "string"
+    },
+    "connectGameObjectToPrefab": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "prefabAssetPath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-prefab-instantiate/SKILL.md
+++ b/.claude/skills/assets-prefab-instantiate/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: assets-prefab-instantiate
+description: Instantiates prefab in the current active scene. Use 'assets-find' tool to find prefab assets in the project.
+---
+
+# Assets / Prefab / Instantiate
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-instantiate --input '{
+  "prefabAssetPath": "string_value",
+  "gameObjectPath": "string_value",
+  "position": "string_value",
+  "rotation": "string_value",
+  "scale": "string_value",
+  "isLocalSpace": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-instantiate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-instantiate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefabAssetPath` | `string` | Yes | Prefab asset path. |
+| `gameObjectPath` | `string` | Yes | GameObject path in the current active scene. |
+| `position` | `any` | No | Transform position of the GameObject. |
+| `rotation` | `any` | No | Transform rotation of the GameObject. Euler angles in degrees. |
+| `scale` | `any` | No | Transform scale of the GameObject. |
+| `isLocalSpace` | `boolean` | No | World or Local space of transform. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "prefabAssetPath": {
+      "type": "string"
+    },
+    "gameObjectPath": {
+      "type": "string"
+    },
+    "position": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "rotation": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "scale": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "isLocalSpace": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "UnityEngine.Vector3": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "prefabAssetPath",
+    "gameObjectPath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-prefab-open/SKILL.md
+++ b/.claude/skills/assets-prefab-open/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: assets-prefab-open
+description: "Open prefab edit mode for a specific GameObject. In the Edit mode you can modify the prefab. The modification will be applied to all instances of the prefab across the project. Note: Please use 'assets-prefab-close' tool later to exit prefab editing mode."
+---
+
+# Assets / Prefab / Open
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-open --input '{
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-open --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-open --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | GameObject that represents prefab instance of an original prefab GameObject. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/assets-prefab-save/SKILL.md
+++ b/.claude/skills/assets-prefab-save/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assets-prefab-save
+description: Save a prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+---
+
+# Assets / Prefab / Save
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-save --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-save --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-save --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-refresh/SKILL.md
+++ b/.claude/skills/assets-refresh/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: assets-refresh
+description: Refreshes the AssetDatabase. Use it if any file was added or updated in the project outside of Unity API. Use it if need to force scripts recompilation when '.cs' file changed.
+---
+
+# Assets / Refresh
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-refresh --input '{
+  "options": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-refresh --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-refresh --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `options` | `any` | No | Asset import options. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "options": {
+      "$ref": "#/$defs/UnityEditor.ImportAssetOptions"
+    }
+  },
+  "$defs": {
+    "UnityEditor.ImportAssetOptions": {
+      "type": "string",
+      "enum": [
+        "Default",
+        "ForceUpdate",
+        "ForceSynchronousImport",
+        "ImportRecursive",
+        "DontDownloadFromCacheServer",
+        "ForceUncompressedImport"
+      ]
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/assets-shader-get-data/SKILL.md
+++ b/.claude/skills/assets-shader-get-data/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: assets-shader-get-data
+description: "Get detailed data about a shader asset in the Unity project. Returns shader properties, subshaders, passes, compilation errors, and supported status. Use 'assets-find' tool with filter 't:Shader' to find shaders, or 'assets-shader-list-all' tool to list all shader names."
+---
+
+# Assets / Shader / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-shader-get-data --input '{
+  "assetRef": "string_value",
+  "includeMessages": "string_value",
+  "includeProperties": "string_value",
+  "includeSubshaders": "string_value",
+  "includeSourceCode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-shader-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-shader-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `includeMessages` | `any` | No | Include compilation error and warning messages. Default: true |
+| `includeProperties` | `any` | No | Include shader properties (uniforms) list. Default: false |
+| `includeSubshaders` | `any` | No | Include subshader and pass structure. Default: false |
+| `includeSourceCode` | `any` | No | Include pass source code in subshader data. Requires 'includeSubshaders' to be true. Can produce very large responses. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "includeMessages": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeProperties": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeSubshaders": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeSourceCode": {
+      "$ref": "#/$defs/System.Boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Boolean": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "assetRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData": {
+      "type": "object",
+      "properties": {
+        "Message": {
+          "type": "string",
+          "description": "The error or warning message text."
+        },
+        "Line": {
+          "type": "integer",
+          "description": "The line number in the shader source where the issue occurs."
+        },
+        "Severity": {
+          "type": "string",
+          "description": "Severity level (e.g. 'Error', 'Warning')."
+        },
+        "Platform": {
+          "type": "string",
+          "description": "The platform on which the error occurs (e.g. 'OpenGLCore', 'D3D11')."
+        }
+      },
+      "required": [
+        "Line"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Property name as used in shader code (e.g. '_MainTex', '_Color')."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Human-readable description/display name of the property."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Property type (e.g. 'Color', 'Float', 'Range', 'Texture', 'Vector', 'Int')."
+        },
+        "Flags": {
+          "type": "string",
+          "description": "Property flags (e.g. 'None', 'HideInInspector', 'PerRendererData')."
+        },
+        "NameId": {
+          "type": "integer",
+          "description": "The unique name ID for this property."
+        },
+        "RangeMin": {
+          "type": "number",
+          "description": "Minimum value for Range properties. Null for non-range properties."
+        },
+        "RangeMax": {
+          "type": "number",
+          "description": "Maximum value for Range properties. Null for non-range properties."
+        },
+        "DefaultTextureName": {
+          "type": "string",
+          "description": "Default texture name for Texture properties. Null if not applicable."
+        },
+        "Attributes": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "Custom attributes applied to this property. Null if none."
+        }
+      },
+      "required": [
+        "NameId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData": {
+      "type": "object",
+      "properties": {
+        "Index": {
+          "type": "integer",
+          "description": "Index of this subshader within the shader."
+        },
+        "PassCount": {
+          "type": "integer",
+          "description": "Number of passes in this subshader."
+        },
+        "Passes": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData>",
+          "description": "List of passes in this subshader. Null if no passes."
+        }
+      },
+      "required": [
+        "Index",
+        "PassCount"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData": {
+      "type": "object",
+      "properties": {
+        "Index": {
+          "type": "integer",
+          "description": "Index of this pass within the subshader."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the pass. Null if unnamed."
+        },
+        "SourceCode": {
+          "type": "string",
+          "description": "Source code of the pass. Null if unavailable."
+        }
+      },
+      "required": [
+        "Index"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+          "description": "Reference to the shader asset for future operations."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Full name of the shader (e.g. 'Standard', 'Universal Render Pipeline/Lit')."
+        },
+        "IsSupported": {
+          "type": "boolean",
+          "description": "Whether the shader is supported on the current GPU and platform."
+        },
+        "RenderQueue": {
+          "type": "integer",
+          "description": "The render queue value of the shader."
+        },
+        "HasErrors": {
+          "type": "boolean",
+          "description": "Whether the shader has any compilation errors."
+        },
+        "PropertyCount": {
+          "type": "integer",
+          "description": "Number of properties exposed by the shader."
+        },
+        "PassCount": {
+          "type": "integer",
+          "description": "Total number of passes in the shader."
+        },
+        "RenderType": {
+          "type": "string",
+          "description": "The RenderType tag value from the first pass, if set."
+        },
+        "Messages": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData>",
+          "description": "Compilation messages including errors and warnings. Null if no messages."
+        },
+        "Properties": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData>",
+          "description": "List of shader properties (uniforms). Null if the shader has no properties."
+        },
+        "Subshaders": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData>",
+          "description": "List of subshaders with their passes. Null if shader data is unavailable."
+        }
+      },
+      "required": [
+        "IsSupported",
+        "RenderQueue",
+        "HasErrors",
+        "PropertyCount",
+        "PassCount"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/assets-shader-list-all/SKILL.md
+++ b/.claude/skills/assets-shader-list-all/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: assets-shader-list-all
+description: List all available shaders in the project assets and packages. Returns their names. Use this to find a shader name for 'assets-material-create' tool.
+---
+
+# Assets / List Shaders
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-shader-list-all --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-shader-list-all --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-shader-list-all --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/console-clear-logs/SKILL.md
+++ b/.claude/skills/console-clear-logs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: console-clear-logs
+description: Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. Useful for isolating errors related to a specific action by clearing logs before performing the action.
+---
+
+# Console / Clear Logs
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool console-clear-logs --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool console-clear-logs --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool console-clear-logs --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/console-get-logs/SKILL.md
+++ b/.claude/skills/console-get-logs/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: console-get-logs
+description: Retrieves Unity Editor logs. Useful for debugging and monitoring Unity Editor activity.
+---
+
+# Console / Get Logs
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool console-get-logs --input '{
+  "maxEntries": 0,
+  "logTypeFilter": "string_value",
+  "includeStackTrace": false,
+  "lastMinutes": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool console-get-logs --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool console-get-logs --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `maxEntries` | `integer` | No | Maximum number of log entries to return. Minimum: 1. Default: 100 |
+| `logTypeFilter` | `any` | No | Filter by log type. 'null' means All. |
+| `includeStackTrace` | `boolean` | No | Include stack traces in the output. Default: false |
+| `lastMinutes` | `integer` | No | Return logs from the last N minutes. If 0, returns all available logs. Default: 0 |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "maxEntries": {
+      "type": "integer"
+    },
+    "logTypeFilter": {
+      "$ref": "#/$defs/UnityEngine.LogType"
+    },
+    "includeStackTrace": {
+      "type": "boolean"
+    },
+    "lastMinutes": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "UnityEngine.LogType": {
+      "type": "string",
+      "enum": [
+        "Error",
+        "Assert",
+        "Warning",
+        "Log",
+        "Exception"
+      ]
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.LogEntry[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.LogEntry": {
+      "type": "object",
+      "properties": {
+        "LogType": {
+          "type": "string",
+          "enum": [
+            "Error",
+            "Assert",
+            "Warning",
+            "Log",
+            "Exception"
+          ]
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "StackTrace": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "LogType",
+        "Timestamp"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.LogEntry[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.LogEntry"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/editor-application-get-state/SKILL.md
+++ b/.claude/skills/editor-application-get-state/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: editor-application-get-state
+description: "Returns available information about 'UnityEditor.EditorApplication'. Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc."
+---
+
+# Editor / Application / Get State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-application-get-state --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-application-get-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-application-get-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData",
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData": {
+      "type": "object",
+      "properties": {
+        "IsPlaying": {
+          "type": "boolean",
+          "description": "Whether the Editor is in Play mode."
+        },
+        "IsPaused": {
+          "type": "boolean",
+          "description": "Whether the Editor is paused."
+        },
+        "IsCompiling": {
+          "type": "boolean",
+          "description": "Is editor currently compiling scripts? (Read Only)"
+        },
+        "IsPlayingOrWillChangePlaymode": {
+          "type": "boolean",
+          "description": "Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)"
+        },
+        "IsUpdating": {
+          "type": "boolean",
+          "description": "True if the Editor is currently refreshing the AssetDatabase. (Read Only)"
+        },
+        "ApplicationContentsPath": {
+          "type": "string",
+          "description": "Path to the Unity editor contents folder. (Read Only)"
+        },
+        "ApplicationPath": {
+          "type": "string",
+          "description": "Gets the path to the Unity Editor application. (Read Only)"
+        },
+        "TimeSinceStartup": {
+          "type": "number",
+          "description": "The time since the editor was started. (Read Only)"
+        }
+      },
+      "required": [
+        "IsPlaying",
+        "IsPaused",
+        "IsCompiling",
+        "IsPlayingOrWillChangePlaymode",
+        "IsUpdating",
+        "TimeSinceStartup"
+      ],
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/editor-application-set-state/SKILL.md
+++ b/.claude/skills/editor-application-set-state/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: editor-application-set-state
+description: Control the Unity Editor application state. You can start, stop, or pause the 'playmode'. Use 'editor-application-get-state' tool to get the current state first.
+---
+
+# Editor / Application / Set State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-application-set-state --input '{
+  "isPlaying": false,
+  "isPaused": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-application-set-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-application-set-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `isPlaying` | `boolean` | No | If true, the 'playmode' will be started. If false, the 'playmode' will be stopped. |
+| `isPaused` | `boolean` | No | If true, the 'playmode' will be paused. If false, the 'playmode' will be resumed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "isPlaying": {
+      "type": "boolean"
+    },
+    "isPaused": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData",
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData": {
+      "type": "object",
+      "properties": {
+        "IsPlaying": {
+          "type": "boolean",
+          "description": "Whether the Editor is in Play mode."
+        },
+        "IsPaused": {
+          "type": "boolean",
+          "description": "Whether the Editor is paused."
+        },
+        "IsCompiling": {
+          "type": "boolean",
+          "description": "Is editor currently compiling scripts? (Read Only)"
+        },
+        "IsPlayingOrWillChangePlaymode": {
+          "type": "boolean",
+          "description": "Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)"
+        },
+        "IsUpdating": {
+          "type": "boolean",
+          "description": "True if the Editor is currently refreshing the AssetDatabase. (Read Only)"
+        },
+        "ApplicationContentsPath": {
+          "type": "string",
+          "description": "Path to the Unity editor contents folder. (Read Only)"
+        },
+        "ApplicationPath": {
+          "type": "string",
+          "description": "Gets the path to the Unity Editor application. (Read Only)"
+        },
+        "TimeSinceStartup": {
+          "type": "number",
+          "description": "The time since the editor was started. (Read Only)"
+        }
+      },
+      "required": [
+        "IsPlaying",
+        "IsPaused",
+        "IsCompiling",
+        "IsPlayingOrWillChangePlaymode",
+        "IsUpdating",
+        "TimeSinceStartup"
+      ],
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/editor-selection-get/SKILL.md
+++ b/.claude/skills/editor-selection-get/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: editor-selection-get
+description: Get information about the current Selection in the Unity Editor. Use 'editor-selection-set' tool to set the selection.
+---
+
+# Editor / Selection / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-selection-get --input '{
+  "includeGameObjects": false,
+  "includeTransforms": false,
+  "includeInstanceIDs": false,
+  "includeAssetGUIDs": false,
+  "includeActiveObject": false,
+  "includeActiveTransform": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-selection-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-selection-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `includeGameObjects` | `boolean` | No |  |
+| `includeTransforms` | `boolean` | No |  |
+| `includeInstanceIDs` | `boolean` | No |  |
+| `includeAssetGUIDs` | `boolean` | No |  |
+| `includeActiveObject` | `boolean` | No |  |
+| `includeActiveTransform` | `boolean` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "includeGameObjects": {
+      "type": "boolean"
+    },
+    "includeTransforms": {
+      "type": "boolean"
+    },
+    "includeInstanceIDs": {
+      "type": "boolean"
+    },
+    "includeAssetGUIDs": {
+      "type": "boolean"
+    },
+    "includeActiveObject": {
+      "type": "boolean"
+    },
+    "includeActiveTransform": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.Int32[]": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData": {
+      "type": "object",
+      "properties": {
+        "GameObjects": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]",
+          "description": "Returns the actual game object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "Transforms": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]",
+          "description": "Returns the top level selection, excluding Prefabs."
+        },
+        "InstanceIDs": {
+          "$ref": "#/$defs/System.Int32[]",
+          "description": "The actual unfiltered selection from the Scene returned as instance ids instead of objects."
+        },
+        "AssetGUIDs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Returns the guids of the selected assets."
+        },
+        "ActiveGameObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Returns the active game object. (The one shown in the inspector)."
+        },
+        "ActiveInstanceID": {
+          "type": "integer",
+          "description": "Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects"
+        },
+        "ActiveObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Returns the actual object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "ActiveTransform": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Returns the active transform. (The one shown in the inspector)."
+        }
+      },
+      "required": [
+        "ActiveInstanceID"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/editor-selection-set/SKILL.md
+++ b/.claude/skills/editor-selection-set/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: editor-selection-set
+description: Set the current Selection in the Unity Editor to the provided objects. Use 'editor-selection-get' tool to get the current selection first.
+---
+
+# Editor / Selection / Set
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-selection-set --input '{
+  "select": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-selection-set --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-selection-set --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `any` | Yes |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "select": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+        "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+      }
+    }
+  },
+  "required": [
+    "select"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.Int32[]": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData": {
+      "type": "object",
+      "properties": {
+        "GameObjects": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]",
+          "description": "Returns the actual game object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "Transforms": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]",
+          "description": "Returns the top level selection, excluding Prefabs."
+        },
+        "InstanceIDs": {
+          "$ref": "#/$defs/System.Int32[]",
+          "description": "The actual unfiltered selection from the Scene returned as instance ids instead of objects."
+        },
+        "AssetGUIDs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Returns the guids of the selected assets."
+        },
+        "ActiveGameObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Returns the active game object. (The one shown in the inspector)."
+        },
+        "ActiveInstanceID": {
+          "type": "integer",
+          "description": "Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects"
+        },
+        "ActiveObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Returns the actual object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "ActiveTransform": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Returns the active transform. (The one shown in the inspector)."
+        }
+      },
+      "required": [
+        "ActiveInstanceID"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-component-add/SKILL.md
+++ b/.claude/skills/gameobject-component-add/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: gameobject-component-add
+description: Add Component to GameObject in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first. Use 'gameobject-component-list-all' tool to find the component type names to add.
+---
+
+# GameObject / Component / Add
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-add --input '{
+  "componentNames": "string_value",
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-add --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-add --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `componentNames` | `any` | Yes | Full name of the Component. It should include full namespace path and the class name. |
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "componentNames": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "componentNames",
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+AddComponentResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+AddComponentResponse": {
+      "type": "object",
+      "properties": {
+        "AddedComponents": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow>",
+          "description": "List of successfully added components."
+        },
+        "Messages": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of success messages for added components."
+        },
+        "Warnings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of warnings encountered during component addition."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during component addition."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-component-destroy/SKILL.md
+++ b/.claude/skills/gameobject-component-destroy/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: gameobject-component-destroy
+description: Destroy one or many components from target GameObject. Can't destroy missed components. Use 'gameobject-find' tool to find the target GameObject and 'gameobject-component-get' to get component details first.
+---
+
+# GameObject / Component / Destroy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-destroy --input '{
+  "gameObjectRef": "string_value",
+  "destroyComponentRefs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-destroy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-destroy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `destroyComponentRefs` | `any` | Yes | Component reference array. Used to find Component at GameObject. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "destroyComponentRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      },
+      "description": "Component reference array. Used to find Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "destroyComponentRefs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyComponentsResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      },
+      "description": "Component reference array. Used to find Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyComponentsResponse": {
+      "type": "object",
+      "properties": {
+        "DestroyedComponents": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList",
+          "description": "List of destroyed components."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-component-get/SKILL.md
+++ b/.claude/skills/gameobject-component-get/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: gameobject-component-get
+description: Get detailed information about a specific Component on a GameObject. Returns component type, enabled state, and optionally serialized fields and properties. Use this to inspect component data before modifying it. Use 'gameobject-find' tool to get the list of all components on the GameObject.
+---
+
+# GameObject / Component / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-get --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "includeFields": false,
+  "includeProperties": false,
+  "deepSerialization": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `componentRef` | `any` | Yes | Component reference. Used to find a Component at GameObject. |
+| `includeFields` | `boolean` | No | Include serialized fields of the component. |
+| `includeProperties` | `boolean` | No | Include serialized properties of the component. |
+| `deepSerialization` | `boolean` | No | Performs deep serialization including all nested objects. Otherwise, only serializes top-level members. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "includeFields": {
+      "type": "boolean"
+    },
+    "includeProperties": {
+      "type": "boolean"
+    },
+    "deepSerialization": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "componentRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+GetComponentResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+GetComponentResponse": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the component for future operations."
+        },
+        "Index": {
+          "type": "integer",
+          "description": "Index of the component in the GameObject's component list."
+        },
+        "Component": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow",
+          "description": "Basic component information (type, enabled state)."
+        },
+        "Fields": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>",
+          "description": "Serialized fields of the component."
+        },
+        "Properties": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>",
+          "description": "Serialized properties of the component."
+        }
+      },
+      "required": [
+        "Index"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-component-list-all/SKILL.md
+++ b/.claude/skills/gameobject-component-list-all/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: gameobject-component-list-all
+description: List C# class names extended from UnityEngine.Component. Use this to find component type names for 'gameobject-component-add' tool. Results are paginated to avoid overwhelming responses.
+---
+
+# GameObject / Component / List All
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-list-all --input '{
+  "search": "string_value",
+  "page": 0,
+  "pageSize": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-list-all --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-list-all --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `search` | `string` | No | Substring for searching components. Could be empty. |
+| `page` | `integer` | No | Page number (0-based). Default is 0. |
+| `pageSize` | `integer` | No | Number of items per page. Default is 5. Max is 500. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "search": {
+      "type": "string"
+    },
+    "page": {
+      "type": "integer"
+    },
+    "pageSize": {
+      "type": "integer"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ComponentListResult"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ComponentListResult": {
+      "type": "object",
+      "properties": {
+        "Items": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Array of component type names for the current page."
+        },
+        "Page": {
+          "type": "integer",
+          "description": "Current page number (0-based)."
+        },
+        "PageSize": {
+          "type": "integer",
+          "description": "Number of items per page."
+        },
+        "TotalCount": {
+          "type": "integer",
+          "description": "Total number of matching components."
+        },
+        "TotalPages": {
+          "type": "integer",
+          "description": "Total number of pages available."
+        }
+      },
+      "required": [
+        "Page",
+        "PageSize",
+        "TotalCount",
+        "TotalPages"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-component-modify/SKILL.md
+++ b/.claude/skills/gameobject-component-modify/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: gameobject-component-modify
+description: Modify a specific Component on a GameObject in opened Prefab or in a Scene. Allows direct modification of component fields and properties without wrapping in GameObject structure. Use 'gameobject-component-get' first to inspect the component structure before modifying.
+---
+
+# GameObject / Component / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-modify --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "componentDiff": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `componentRef` | `any` | Yes | Component reference. Used to find a Component at GameObject. |
+| `componentDiff` | `any` | Yes | The component data to apply. Should contain 'fields' and/or 'props' with the values to modify.
+Only include the fields/properties you want to change.
+Any unknown or invalid fields and properties will be reported in the response. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "componentDiff": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "componentRef",
+    "componentDiff"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ModifyComponentResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ModifyComponentResponse": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the modified component."
+        },
+        "Index": {
+          "type": "integer",
+          "description": "Index of the component in the GameObject's component list."
+        },
+        "Component": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow",
+          "description": "Updated component information after modification."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "Success",
+        "Index"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-create/SKILL.md
+++ b/.claude/skills/gameobject-create/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: gameobject-create
+description: Create a new GameObject in opened Prefab or in a Scene. If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.
+---
+
+# GameObject / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-create --input '{
+  "name": "string_value",
+  "parentGameObjectRef": "string_value",
+  "position": "string_value",
+  "rotation": "string_value",
+  "scale": "string_value",
+  "isLocalSpace": false,
+  "primitiveType": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | Name of the new GameObject. |
+| `parentGameObjectRef` | `any` | No | Parent GameObject reference. If not provided, the GameObject will be created at the root of the scene or prefab. |
+| `position` | `any` | No | Transform position of the GameObject. |
+| `rotation` | `any` | No | Transform rotation of the GameObject. Euler angles in degrees. |
+| `scale` | `any` | No | Transform scale of the GameObject. |
+| `isLocalSpace` | `boolean` | No | World or Local space of transform. |
+| `primitiveType` | `any` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "parentGameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "position": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "rotation": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "scale": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "isLocalSpace": {
+      "type": "boolean"
+    },
+    "primitiveType": {
+      "$ref": "#/$defs/UnityEngine.PrimitiveType"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "UnityEngine.Vector3": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "additionalProperties": false
+    },
+    "UnityEngine.PrimitiveType": {
+      "type": "string",
+      "enum": [
+        "Sphere",
+        "Capsule",
+        "Cylinder",
+        "Cube",
+        "Plane",
+        "Quad"
+      ]
+    }
+  },
+  "required": [
+    "name"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-destroy/SKILL.md
+++ b/.claude/skills/gameobject-destroy/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gameobject-destroy
+description: Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first.
+---
+
+# GameObject / Destroy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-destroy --input '{
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-destroy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-destroy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyGameObjectResult"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyGameObjectResult": {
+      "type": "object",
+      "properties": {
+        "DestroyedName": {
+          "type": "string",
+          "description": "Name of the destroyed GameObject."
+        },
+        "DestroyedPath": {
+          "type": "string",
+          "description": "Hierarchy path of the destroyed GameObject."
+        },
+        "DestroyedInstanceId": {
+          "type": "integer",
+          "description": "Instance ID of the destroyed GameObject."
+        }
+      },
+      "required": [
+        "DestroyedInstanceId"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-duplicate/SKILL.md
+++ b/.claude/skills/gameobject-duplicate/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: gameobject-duplicate
+description: Duplicate GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+---
+
+# GameObject / Duplicate
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-duplicate --input '{
+  "gameObjectRefs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-duplicate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-duplicate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | Array of GameObjects in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRefs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-find/SKILL.md
+++ b/.claude/skills/gameobject-find/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: gameobject-find
+description: Finds specific GameObject by provided information in opened Prefab or in a Scene. First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. If no opened Prefab it looks into current active scene. Returns GameObject information and its children. Also, it returns Components preview just for the target GameObject.
+---
+
+# GameObject / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-find --input '{
+  "gameObjectRef": "string_value",
+  "includeData": false,
+  "includeComponents": false,
+  "includeBounds": false,
+  "includeHierarchy": false,
+  "hierarchyDepth": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `includeData` | `boolean` | No | Include editable GameObject data (tag, layer, etc). |
+| `includeComponents` | `boolean` | No | Include attached components references. |
+| `includeBounds` | `boolean` | No | Include 3D bounds of the GameObject. |
+| `includeHierarchy` | `boolean` | No | Include hierarchy metadata. |
+| `hierarchyDepth` | `integer` | No | Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "includeData": {
+      "type": "boolean"
+    },
+    "includeComponents": {
+      "type": "boolean"
+    },
+    "includeBounds": {
+      "type": "boolean"
+    },
+    "includeHierarchy": {
+      "type": "boolean"
+    },
+    "hierarchyDepth": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "UnityEngine.Bounds": {
+      "type": "object",
+      "properties": {
+        "center": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "size": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "required": [
+        "center",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sceneName": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "activeSelf": {
+          "type": "boolean"
+        },
+        "activeInHierarchy": {
+          "type": "boolean"
+        },
+        "children": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>"
+        }
+      },
+      "required": [
+        "instanceID",
+        "activeSelf",
+        "activeInHierarchy"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Find GameObject in opened Prefab or in the active Scene."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "GameObject editable data (tag, layer, etc)."
+        },
+        "Bounds": {
+          "$ref": "#/$defs/UnityEngine.Bounds",
+          "description": "Bounds of the GameObject."
+        },
+        "Hierarchy": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata",
+          "description": "Hierarchy metadata of the GameObject."
+        },
+        "Components": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]",
+          "description": "Attached components shallow data of the GameObject (Read-only, use Component modification tool for modification)."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-modify/SKILL.md
+++ b/.claude/skills/gameobject-modify/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: gameobject-modify
+description: Modify GameObject fields and properties in opened Prefab or in a Scene. You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.
+---
+
+# GameObject / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-modify --input '{
+  "gameObjectRefs": "string_value",
+  "gameObjectDiffs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | Array of GameObjects in opened Prefab or in the active Scene. |
+| `gameObjectDiffs` | `any` | Yes | Each item in the array represents a GameObject modification of the 'gameObjectRefs' at the same index. Usually a GameObject is a container for components. Each component may have fields and properties for modification. If you need to modify components of a GameObject, please use 'gameobject-component-modify' tool. Ignore values that should not be modified. Any unknown or wrong located fields and properties will be ignored. Check the result of this command to see what was changed. The ignored fields and properties will be listed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    },
+    "gameObjectDiffs": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRefs",
+    "gameObjectDiffs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.Logs"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.LogEntry": {
+      "type": "object",
+      "properties": {
+        "Depth": {
+          "type": "integer"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Success",
+            "Warning",
+            "Error",
+            "Critical"
+          ]
+        }
+      },
+      "required": [
+        "Depth",
+        "Type"
+      ]
+    },
+    "com.IvanMurzak.ReflectorNet.Model.Logs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.LogEntry"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/gameobject-set-parent/SKILL.md
+++ b/.claude/skills/gameobject-set-parent/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: gameobject-set-parent
+description: Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+---
+
+# GameObject / Set Parent
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-set-parent --input '{
+  "gameObjectRefs": "string_value",
+  "parentGameObjectRef": "string_value",
+  "worldPositionStays": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-set-parent --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-set-parent --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | List of references to the GameObjects to set new parent. |
+| `parentGameObjectRef` | `any` | Yes | Reference to the parent GameObject. |
+| `worldPositionStays` | `boolean` | No | A boolean flag indicating whether the GameObject's world position should remain unchanged when setting its parent. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    },
+    "parentGameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "worldPositionStays": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRefs",
+    "parentGameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/object-get-data/SKILL.md
+++ b/.claude/skills/object-get-data/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: object-get-data
+description: Get data of the specified Unity Object. Returns serialized data of the object including its properties and fields. If need to modify the data use 'object-modify' tool.
+---
+
+# Object / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool object-get-data --input '{
+  "objectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool object-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool object-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectRef` | `any` | Yes | Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "objectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    }
+  },
+  "required": [
+    "objectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/object-modify/SKILL.md
+++ b/.claude/skills/object-modify/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: object-modify
+description: Modify the specified Unity Object. Allows direct modification of object fields and properties. Use 'object-get-data' first to inspect the object structure before modifying.
+---
+
+# Object / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool object-modify --input '{
+  "objectRef": "string_value",
+  "objectDiff": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool object-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool object-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectRef` | `any` | Yes | Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object. |
+| `objectDiff` | `any` | Yes | The object data to apply. Should contain 'fields' and/or 'props' with the values to modify.
+Only include the fields/properties you want to change.
+Any unknown or invalid fields and properties will be reported in the response. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "objectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef"
+    },
+    "objectDiff": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "objectRef",
+    "objectDiff"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Object+ModifyObjectResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Object+ModifyObjectResponse": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Reference to the modified object."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Updated object data after modification."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "Success"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/package-add/SKILL.md
+++ b/.claude/skills/package-add/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: package-add
+description: "Install a package from the Unity Package Manager registry, Git URL, or local path. This operation modifies the project's manifest.json and triggers package resolution. Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. Use 'package-search' tool to search for packages and 'package-list' to list installed packages."
+---
+
+# Package Manager / Add
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-add --input '{
+  "packageId": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-add --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-add --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `packageId` | `string` | Yes | The package ID to install. Formats: Package ID 'com.unity.textmeshpro' (installs latest compatible version), Package ID with version 'com.unity.textmeshpro@3.0.6', Git URL 'https://github.com/user/repo.git', Git URL with branch/tag 'https://github.com/user/repo.git#v1.0.0', Local path 'file:../MyPackage'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "packageId"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/package-list/SKILL.md
+++ b/.claude/skills/package-list/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: package-list
+description: List all packages installed in the Unity project (UPM packages). Returns information about each installed package including name, version, source, and description. Use this to check which packages are currently installed before adding or removing packages.
+---
+
+# Package Manager / List Installed
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-list --input '{
+  "sourceFilter": "string_value",
+  "nameFilter": "string_value",
+  "directDependenciesOnly": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-list --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-list --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourceFilter` | `string` | No | Filter packages by source. |
+| `nameFilter` | `string` | No | Filter packages by name, display name, or description (case-insensitive). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. |
+| `directDependenciesOnly` | `boolean` | No | Include only direct dependencies (packages in manifest.json). If false, includes all resolved packages. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourceFilter": {
+      "type": "string",
+      "enum": [
+        "All",
+        "Registry",
+        "Embedded",
+        "Local",
+        "Git",
+        "BuiltIn",
+        "LocalTarball"
+      ]
+    },
+    "nameFilter": {
+      "type": "string"
+    },
+    "directDependenciesOnly": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The official Unity name of the package used as the package ID."
+        },
+        "DisplayName": {
+          "type": "string",
+          "description": "The display name of the package."
+        },
+        "Version": {
+          "type": "string",
+          "description": "The version of the package."
+        },
+        "Description": {
+          "type": "string",
+          "description": "A brief description of the package."
+        },
+        "Source": {
+          "type": "string",
+          "description": "The source of the package (Registry, Embedded, Local, Git, etc.)."
+        },
+        "Category": {
+          "type": "string",
+          "description": "The category of the package."
+        }
+      },
+      "description": "Package information returned from package list operation."
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData",
+        "description": "Package information returned from package list operation."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/package-remove/SKILL.md
+++ b/.claude/skills/package-remove/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: package-remove
+description: "Remove (uninstall) a package from the Unity project. This removes the package from the project's manifest.json and triggers package resolution. Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. Use 'package-list' tool to list installed packages first."
+---
+
+# Package Manager / Remove
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-remove --input '{
+  "packageId": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-remove --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-remove --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `packageId` | `string` | Yes | The ID of the package to remove. Example: 'com.unity.textmeshpro'. Do not include version number. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "packageId"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/package-search/SKILL.md
+++ b/.claude/skills/package-search/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: package-search
+description: "Search for packages in both Unity Package Manager registry and installed packages. Use this to find packages by name before installing them. Returns available versions and installation status. Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. Note: Online mode fetches exact matches from live registry, then supplements with cached substring matches."
+---
+
+# Package Manager / Search
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-search --input '{
+  "query": "string_value",
+  "maxResults": 0,
+  "offlineMode": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-search --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-search --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | Yes | The package id, name, or description. Can be: Full package id 'com.unity.textmeshpro', Full package name 'TextMesh Pro', Partial name 'TextMesh' (will search in Unity registry and installed packages), Description keyword 'rendering' (searches in package descriptions). |
+| `maxResults` | `integer` | No | Maximum number of results to return. Default: 10 |
+| `offlineMode` | `boolean` | No | Whether to perform the search in offline mode (uses cached registry data only). Default: true. Set to false to fetch latest exact matches from Unity registry. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string"
+    },
+    "maxResults": {
+      "type": "integer"
+    },
+    "offlineMode": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "query"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The official Unity name of the package used as the package ID."
+        },
+        "DisplayName": {
+          "type": "string",
+          "description": "The display name of the package."
+        },
+        "LatestVersion": {
+          "type": "string",
+          "description": "The latest version available in the registry."
+        },
+        "Description": {
+          "type": "string",
+          "description": "A brief description of the package."
+        },
+        "IsInstalled": {
+          "type": "boolean",
+          "description": "Whether this package is already installed in the project."
+        },
+        "InstalledVersion": {
+          "type": "string",
+          "description": "The currently installed version (if installed)."
+        },
+        "AvailableVersions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "Available versions of this package (up to 5 most recent)."
+        }
+      },
+      "required": [
+        "IsInstalled"
+      ],
+      "description": "Package search result with available versions."
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult",
+        "description": "Package search result with available versions."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/particle-system-get/SKILL.md
+++ b/.claude/skills/particle-system-get/SKILL.md
@@ -1,0 +1,518 @@
+---
+name: particle-system-get
+description: Get detailed information about a ParticleSystem component on a GameObject. Returns particle system state and optionally serialized data for each module. Use the boolean flags to request specific modules. Use this to inspect ParticleSystem data before modifying it.
+---
+
+# ParticleSystem / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool particle-system-get --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "includeMain": false,
+  "includeEmission": false,
+  "includeShape": false,
+  "includeVelocityOverLifetime": false,
+  "includeLimitVelocityOverLifetime": false,
+  "includeInheritVelocity": false,
+  "includeLifetimeByEmitterSpeed": false,
+  "includeForceOverLifetime": false,
+  "includeColorOverLifetime": false,
+  "includeColorBySpeed": false,
+  "includeSizeOverLifetime": false,
+  "includeSizeBySpeed": false,
+  "includeRotationOverLifetime": false,
+  "includeRotationBySpeed": false,
+  "includeExternalForces": false,
+  "includeNoise": false,
+  "includeCollision": false,
+  "includeTrigger": false,
+  "includeSubEmitters": false,
+  "includeTextureSheetAnimation": false,
+  "includeLights": false,
+  "includeTrails": false,
+  "includeCustomData": false,
+  "includeRenderer": false,
+  "includeAll": false,
+  "deepSerialization": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool particle-system-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool particle-system-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Reference to the GameObject containing the ParticleSystem component. |
+| `componentRef` | `any` | No | Optional reference to a specific ParticleSystem component if the GameObject has multiple. If not provided, uses the first ParticleSystem found. |
+| `includeMain` | `boolean` | No | Include Main module data (duration, looping, prewarm, startDelay, startLifetime, startSpeed, startSize, startRotation, startColor, gravityModifier, simulationSpace, scalingMode, playOnAwake, maxParticles, etc.). |
+| `includeEmission` | `boolean` | No | Include Emission module data (rateOverTime, rateOverDistance, bursts). |
+| `includeShape` | `boolean` | No | Include Shape module data (shapeType, radius, angle, arc, position, rotation, scale, mesh, texture, etc.). |
+| `includeVelocityOverLifetime` | `boolean` | No | Include Velocity over Lifetime module data (x, y, z, space, orbital, radial, speedModifier). |
+| `includeLimitVelocityOverLifetime` | `boolean` | No | Include Limit Velocity over Lifetime module data (limit, dampen, separateAxes, drag). |
+| `includeInheritVelocity` | `boolean` | No | Include Inherit Velocity module data (mode, curve). |
+| `includeLifetimeByEmitterSpeed` | `boolean` | No | Include Lifetime by Emitter Speed module data (curve, range). |
+| `includeForceOverLifetime` | `boolean` | No | Include Force over Lifetime module data (x, y, z, space, randomized). |
+| `includeColorOverLifetime` | `boolean` | No | Include Color over Lifetime module data (color gradient). |
+| `includeColorBySpeed` | `boolean` | No | Include Color by Speed module data (color, range). |
+| `includeSizeOverLifetime` | `boolean` | No | Include Size over Lifetime module data (size curve, separateAxes). |
+| `includeSizeBySpeed` | `boolean` | No | Include Size by Speed module data (size, range). |
+| `includeRotationOverLifetime` | `boolean` | No | Include Rotation over Lifetime module data (angular velocity, separateAxes). |
+| `includeRotationBySpeed` | `boolean` | No | Include Rotation by Speed module data (angular velocity, range). |
+| `includeExternalForces` | `boolean` | No | Include External Forces module data (multiplier, influenceFilter). |
+| `includeNoise` | `boolean` | No | Include Noise module data (strength, frequency, scrollSpeed, damping, octaves, quality, remap). |
+| `includeCollision` | `boolean` | No | Include Collision module data (type, mode, planes, dampen, bounce, lifetimeLoss). |
+| `includeTrigger` | `boolean` | No | Include Trigger module data (inside, outside, enter, exit actions). |
+| `includeSubEmitters` | `boolean` | No | Include Sub Emitters module data (birth, collision, death, trigger, manual emitters). |
+| `includeTextureSheetAnimation` | `boolean` | No | Include Texture Sheet Animation module data (mode, tiles, animation, frameOverTime). |
+| `includeLights` | `boolean` | No | Include Lights module data (ratio, light, color, range, intensity). |
+| `includeTrails` | `boolean` | No | Include Trails module data (mode, ratio, lifetime, width, color). |
+| `includeCustomData` | `boolean` | No | Include Custom Data module data (modes, vectors, colors). |
+| `includeRenderer` | `boolean` | No | Include Renderer module data (renderMode, material, sortMode, alignment, shadows). |
+| `includeAll` | `boolean` | No | Include ALL modules data. Overrides individual flags. |
+| `deepSerialization` | `boolean` | No | Performs deep serialization including all nested objects. Otherwise, only serializes top-level members. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "includeMain": {
+      "type": "boolean"
+    },
+    "includeEmission": {
+      "type": "boolean"
+    },
+    "includeShape": {
+      "type": "boolean"
+    },
+    "includeVelocityOverLifetime": {
+      "type": "boolean"
+    },
+    "includeLimitVelocityOverLifetime": {
+      "type": "boolean"
+    },
+    "includeInheritVelocity": {
+      "type": "boolean"
+    },
+    "includeLifetimeByEmitterSpeed": {
+      "type": "boolean"
+    },
+    "includeForceOverLifetime": {
+      "type": "boolean"
+    },
+    "includeColorOverLifetime": {
+      "type": "boolean"
+    },
+    "includeColorBySpeed": {
+      "type": "boolean"
+    },
+    "includeSizeOverLifetime": {
+      "type": "boolean"
+    },
+    "includeSizeBySpeed": {
+      "type": "boolean"
+    },
+    "includeRotationOverLifetime": {
+      "type": "boolean"
+    },
+    "includeRotationBySpeed": {
+      "type": "boolean"
+    },
+    "includeExternalForces": {
+      "type": "boolean"
+    },
+    "includeNoise": {
+      "type": "boolean"
+    },
+    "includeCollision": {
+      "type": "boolean"
+    },
+    "includeTrigger": {
+      "type": "boolean"
+    },
+    "includeSubEmitters": {
+      "type": "boolean"
+    },
+    "includeTextureSheetAnimation": {
+      "type": "boolean"
+    },
+    "includeLights": {
+      "type": "boolean"
+    },
+    "includeTrails": {
+      "type": "boolean"
+    },
+    "includeCustomData": {
+      "type": "boolean"
+    },
+    "includeRenderer": {
+      "type": "boolean"
+    },
+    "includeAll": {
+      "type": "boolean"
+    },
+    "deepSerialization": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.GetParticleSystemResponse",
+      "description": "Response containing ParticleSystem data with requested modules."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.GetParticleSystemResponse": {
+      "type": "object",
+      "properties": {
+        "gameObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Reference to the GameObject containing the ParticleSystem component."
+        },
+        "componentRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the ParticleSystem component."
+        },
+        "componentIndex": {
+          "type": "integer",
+          "description": "Index of the ParticleSystem component in the GameObject's component list."
+        },
+        "isPlaying": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently playing."
+        },
+        "isPaused": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently paused."
+        },
+        "isEmitting": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently emitting."
+        },
+        "isStopped": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently stopped."
+        },
+        "particleCount": {
+          "type": "integer",
+          "description": "Current particle count."
+        },
+        "time": {
+          "type": "number",
+          "description": "Current simulation time."
+        },
+        "main": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Main module data."
+        },
+        "emission": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Emission module data."
+        },
+        "shape": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Shape module data."
+        },
+        "velocityOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Velocity over Lifetime module data."
+        },
+        "limitVelocityOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Limit Velocity over Lifetime module data."
+        },
+        "inheritVelocity": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Inherit Velocity module data."
+        },
+        "lifetimeByEmitterSpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Lifetime by Emitter Speed module data."
+        },
+        "forceOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Force over Lifetime module data."
+        },
+        "colorOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Color over Lifetime module data."
+        },
+        "colorBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Color by Speed module data."
+        },
+        "sizeOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Size over Lifetime module data."
+        },
+        "sizeBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Size by Speed module data."
+        },
+        "rotationOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Rotation over Lifetime module data."
+        },
+        "rotationBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Rotation by Speed module data."
+        },
+        "externalForces": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "External Forces module data."
+        },
+        "noise": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Noise module data."
+        },
+        "collision": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Collision module data."
+        },
+        "trigger": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Trigger module data."
+        },
+        "subEmitters": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Sub Emitters module data."
+        },
+        "textureSheetAnimation": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Texture Sheet Animation module data."
+        },
+        "lights": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Lights module data."
+        },
+        "trails": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Trails module data."
+        },
+        "customData": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Custom Data module data."
+        },
+        "renderer": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Renderer module data."
+        }
+      },
+      "required": [
+        "componentIndex",
+        "isPlaying",
+        "isPaused",
+        "isEmitting",
+        "isStopped",
+        "particleCount",
+        "time"
+      ],
+      "description": "Response containing ParticleSystem data with requested modules."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/particle-system-modify/SKILL.md
+++ b/.claude/skills/particle-system-modify/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: particle-system-modify
+description: Modify a ParticleSystem component on a GameObject. Provide the data model with only the modules you want to change. Use 'particle-system-get' first to inspect the ParticleSystem structure before modifying. Only include the modules and properties you want to change.
+---
+
+# ParticleSystem / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool particle-system-modify --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "main": "string_value",
+  "emission": "string_value",
+  "shape": "string_value",
+  "velocityOverLifetime": "string_value",
+  "limitVelocityOverLifetime": "string_value",
+  "inheritVelocity": "string_value",
+  "lifetimeByEmitterSpeed": "string_value",
+  "forceOverLifetime": "string_value",
+  "colorOverLifetime": "string_value",
+  "colorBySpeed": "string_value",
+  "sizeOverLifetime": "string_value",
+  "sizeBySpeed": "string_value",
+  "rotationOverLifetime": "string_value",
+  "rotationBySpeed": "string_value",
+  "externalForces": "string_value",
+  "noise": "string_value",
+  "collision": "string_value",
+  "trigger": "string_value",
+  "subEmitters": "string_value",
+  "textureSheetAnimation": "string_value",
+  "lights": "string_value",
+  "trails": "string_value",
+  "customData": "string_value",
+  "renderer": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool particle-system-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool particle-system-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Reference to the GameObject containing the ParticleSystem component. |
+| `componentRef` | `any` | No | Optional reference to a specific ParticleSystem component if the GameObject has multiple. If not provided, uses the first ParticleSystem found. |
+| `main` | `any` | No | Main module data to apply. Only include properties you want to change. |
+| `emission` | `any` | No | Emission module data to apply. Only include properties you want to change. |
+| `shape` | `any` | No | Shape module data to apply. Only include properties you want to change. |
+| `velocityOverLifetime` | `any` | No | Velocity over Lifetime module data to apply. Only include properties you want to change. |
+| `limitVelocityOverLifetime` | `any` | No | Limit Velocity over Lifetime module data to apply. Only include properties you want to change. |
+| `inheritVelocity` | `any` | No | Inherit Velocity module data to apply. Only include properties you want to change. |
+| `lifetimeByEmitterSpeed` | `any` | No | Lifetime by Emitter Speed module data to apply. Only include properties you want to change. |
+| `forceOverLifetime` | `any` | No | Force over Lifetime module data to apply. Only include properties you want to change. |
+| `colorOverLifetime` | `any` | No | Color over Lifetime module data to apply. Only include properties you want to change. |
+| `colorBySpeed` | `any` | No | Color by Speed module data to apply. Only include properties you want to change. |
+| `sizeOverLifetime` | `any` | No | Size over Lifetime module data to apply. Only include properties you want to change. |
+| `sizeBySpeed` | `any` | No | Size by Speed module data to apply. Only include properties you want to change. |
+| `rotationOverLifetime` | `any` | No | Rotation over Lifetime module data to apply. Only include properties you want to change. |
+| `rotationBySpeed` | `any` | No | Rotation by Speed module data to apply. Only include properties you want to change. |
+| `externalForces` | `any` | No | External Forces module data to apply. Only include properties you want to change. |
+| `noise` | `any` | No | Noise module data to apply. Only include properties you want to change. |
+| `collision` | `any` | No | Collision module data to apply. Only include properties you want to change. |
+| `trigger` | `any` | No | Trigger module data to apply. Only include properties you want to change. |
+| `subEmitters` | `any` | No | Sub Emitters module data to apply. Only include properties you want to change. |
+| `textureSheetAnimation` | `any` | No | Texture Sheet Animation module data to apply. Only include properties you want to change. |
+| `lights` | `any` | No | Lights module data to apply. Only include properties you want to change. |
+| `trails` | `any` | No | Trails module data to apply. Only include properties you want to change. |
+| `customData` | `any` | No | Custom Data module data to apply. Only include properties you want to change. |
+| `renderer` | `any` | No | Renderer module data to apply. Only include properties you want to change. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "main": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "emission": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "shape": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "velocityOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "limitVelocityOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "inheritVelocity": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "lifetimeByEmitterSpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "forceOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "colorOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "colorBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "sizeOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "sizeBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "rotationOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "rotationBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "externalForces": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "noise": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "collision": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "trigger": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "subEmitters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "textureSheetAnimation": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "lights": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "trails": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "customData": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "renderer": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.ModifyParticleSystemResponse",
+      "description": "Response containing the result of modifying a ParticleSystem."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.ModifyParticleSystemResponse": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "gameObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Reference to the GameObject containing the ParticleSystem component."
+        },
+        "componentRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the modified ParticleSystem component."
+        },
+        "componentIndex": {
+          "type": "integer",
+          "description": "Index of the ParticleSystem component in the GameObject's component list."
+        },
+        "logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "success",
+        "componentIndex"
+      ],
+      "description": "Response containing the result of modifying a ParticleSystem."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/ping/SKILL.md
+++ b/.claude/skills/ping/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ping
+description: Lightweight readiness probe. Returns the input message or 'pong' if omitted.
+---
+
+# Ping
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool ping --input '{
+  "message": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool ping --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool ping --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message` | `string` | No | Optional message to echo back. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/reflection-method-call/SKILL.md
+++ b/.claude/skills/reflection-method-call/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: reflection-method-call
+description: Call C# method. Any method could be called, even private methods. It requires to receive proper method schema. Use 'reflection-method-find' to find available method before using it. Receives input parameters and returns result.
+---
+
+# Method C# / Call
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool reflection-method-call --input '{
+  "filter": "string_value",
+  "knownNamespace": false,
+  "typeNameMatchLevel": 0,
+  "methodNameMatchLevel": 0,
+  "parametersMatchLevel": 0,
+  "targetObject": "string_value",
+  "inputParameters": "string_value",
+  "executeInMainThread": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool reflection-method-call --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool reflection-method-call --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `any` | Yes | Method reference. Used to find method in codebase of the project. |
+| `knownNamespace` | `boolean` | No | Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false. |
+| `typeNameMatchLevel` | `integer` | No | Minimal match level for 'typeName'. 0 - ignore 'filter.typeName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `methodNameMatchLevel` | `integer` | No | Minimal match level for 'MethodName'. 0 - ignore 'filter.MethodName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `parametersMatchLevel` | `integer` | No | Minimal match level for 'Parameters'. 0 - ignore 'filter.Parameters', 1 - parameters count is the same, 2 - equals (default value). |
+| `targetObject` | `any` | No | Specify target object to call method on. Should be null if the method is static or if there is no specific target instance. New instance of the specified class will be created if the method is instance method and the targetObject is null. Required: type - full type name of the object to call method on, value - serialized object value (it will be deserialized to the specified type). |
+| `inputParameters` | `any` | No | Method input parameters. Per each parameter specify: type - full type name of the object to call method on, name - parameter name, value - serialized object value (it will be deserialized to the specified type). |
+| `executeInMainThread` | `boolean` | No | Set to true if the method should be executed in the main thread. Otherwise, set to false. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef"
+    },
+    "knownNamespace": {
+      "type": "boolean"
+    },
+    "typeNameMatchLevel": {
+      "type": "integer"
+    },
+    "methodNameMatchLevel": {
+      "type": "integer"
+    },
+    "parametersMatchLevel": {
+      "type": "integer"
+    },
+    "targetObject": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "inputParameters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    },
+    "executeInMainThread": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter",
+        "description": "Parameter of a method. Contains type and name of the parameter."
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Type of the parameter including namespace. Sample: 'System.String', 'System.Int32', 'UnityEngine.GameObject', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the parameter. It may be empty if the name is unknown."
+        }
+      },
+      "description": "Parameter of a method. Contains type and name of the parameter."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the class. It may be empty if the class is in the global namespace or the namespace is unknown."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Class name, or substring a class name. It may be empty if the class is unknown."
+        },
+        "methodName": {
+          "type": "string",
+          "description": "Method name, or substring of the method name. It may be empty if the method is unknown."
+        },
+        "inputParameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>",
+          "description": "List of input parameters. Can be null if the method has no parameters or the parameters are unknown."
+        }
+      },
+      "description": "Method reference. Used to find method in codebase of the project."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "filter"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/reflection-method-find/SKILL.md
+++ b/.claude/skills/reflection-method-find/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: reflection-method-find
+description: Find method in the project using C# Reflection. It looks for all assemblies in the project and finds method by its name, class name and parameters. Even private methods are available. Use 'reflection-method-call' to call the method after finding it.
+---
+
+# Method C# / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool reflection-method-find --input '{
+  "filter": "string_value",
+  "knownNamespace": false,
+  "typeNameMatchLevel": 0,
+  "methodNameMatchLevel": 0,
+  "parametersMatchLevel": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool reflection-method-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool reflection-method-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `any` | Yes | Method reference. Used to find method in codebase of the project. |
+| `knownNamespace` | `boolean` | No | Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false. |
+| `typeNameMatchLevel` | `integer` | No | Minimal match level for 'typeName'. 0 - ignore 'filter.typeName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `methodNameMatchLevel` | `integer` | No | Minimal match level for 'MethodName'. 0 - ignore 'filter.MethodName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `parametersMatchLevel` | `integer` | No | Minimal match level for 'Parameters'. 0 - ignore 'filter.Parameters' (default value), 1 - parameters count is the same, 2 - equals. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef"
+    },
+    "knownNamespace": {
+      "type": "boolean"
+    },
+    "typeNameMatchLevel": {
+      "type": "integer"
+    },
+    "methodNameMatchLevel": {
+      "type": "integer"
+    },
+    "parametersMatchLevel": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter",
+        "description": "Parameter of a method. Contains type and name of the parameter."
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Type of the parameter including namespace. Sample: 'System.String', 'System.Int32', 'UnityEngine.GameObject', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the parameter. It may be empty if the name is unknown."
+        }
+      },
+      "description": "Parameter of a method. Contains type and name of the parameter."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the class. It may be empty if the class is in the global namespace or the namespace is unknown."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Class name, or substring a class name. It may be empty if the class is unknown."
+        },
+        "methodName": {
+          "type": "string",
+          "description": "Method name, or substring of the method name. It may be empty if the method is unknown."
+        },
+        "inputParameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>",
+          "description": "List of input parameters. Can be null if the method has no parameters or the parameters are unknown."
+        }
+      },
+      "description": "Method reference. Used to find method in codebase of the project."
+    }
+  },
+  "required": [
+    "filter"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-create/SKILL.md
+++ b/.claude/skills/scene-create/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: scene-create
+description: Create new scene in the project assets. Use 'scene-list-opened' tool to list all opened scenes after creation.
+---
+
+# Scene / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-create --input '{
+  "path": "string_value",
+  "newSceneSetup": "string_value",
+  "newSceneMode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Yes | Path to the scene file. Should end with ".unity" extension. |
+| `newSceneSetup` | `any` | No |  |
+| `newSceneMode` | `any` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "newSceneSetup": {
+      "$ref": "#/$defs/UnityEditor.SceneManagement.NewSceneSetup"
+    },
+    "newSceneMode": {
+      "$ref": "#/$defs/UnityEditor.SceneManagement.NewSceneMode"
+    }
+  },
+  "$defs": {
+    "UnityEditor.SceneManagement.NewSceneSetup": {
+      "type": "string",
+      "enum": [
+        "EmptyScene",
+        "DefaultGameObjects"
+      ]
+    },
+    "UnityEditor.SceneManagement.NewSceneMode": {
+      "type": "string",
+      "enum": [
+        "Single",
+        "Additive"
+      ]
+    }
+  },
+  "required": [
+    "path"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-get-data/SKILL.md
+++ b/.claude/skills/scene-get-data/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: scene-get-data
+description: This tool retrieves the list of root GameObjects in the specified scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-get-data --input '{
+  "openedSceneName": "string_value",
+  "includeRootGameObjects": false,
+  "includeChildrenDepth": 0,
+  "includeBounds": false,
+  "includeData": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `openedSceneName` | `string` | No | Name of the opened scene. If empty or null, the active scene will be used. |
+| `includeRootGameObjects` | `boolean` | No | If true, includes root GameObjects in the scene data. |
+| `includeChildrenDepth` | `integer` | No | Determines the depth of the hierarchy to include. |
+| `includeBounds` | `boolean` | No | If true, includes bounding box information for GameObjects. |
+| `includeData` | `boolean` | No | If true, includes component data for GameObjects. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "openedSceneName": {
+      "type": "string"
+    },
+    "includeRootGameObjects": {
+      "type": "boolean"
+    },
+    "includeChildrenDepth": {
+      "type": "integer"
+    },
+    "includeBounds": {
+      "type": "boolean"
+    },
+    "includeData": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneData",
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Find GameObject in opened Prefab or in the active Scene."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "GameObject editable data (tag, layer, etc)."
+        },
+        "Bounds": {
+          "$ref": "#/$defs/UnityEngine.Bounds",
+          "description": "Bounds of the GameObject."
+        },
+        "Hierarchy": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata",
+          "description": "Hierarchy metadata of the GameObject."
+        },
+        "Components": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]",
+          "description": "Attached components shallow data of the GameObject (Read-only, use Component modification tool for modification)."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "UnityEngine.Bounds": {
+      "type": "object",
+      "properties": {
+        "center": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "size": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "required": [
+        "center",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sceneName": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "activeSelf": {
+          "type": "boolean"
+        },
+        "activeInHierarchy": {
+          "type": "boolean"
+        },
+        "children": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>"
+        }
+      },
+      "required": [
+        "instanceID",
+        "activeSelf",
+        "activeInHierarchy"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneData": {
+      "type": "object",
+      "properties": {
+        "RootGameObjects": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData>"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-list-opened/SKILL.md
+++ b/.claude/skills/scene-list-opened/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: scene-list-opened
+description: Returns the list of currently opened scenes in Unity Editor. Use 'scene-get-data' tool to get detailed information about a specific scene.
+---
+
+# Scene / List Opened
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-list-opened --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-list-opened --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-list-opened --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-open/SKILL.md
+++ b/.claude/skills/scene-open/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: scene-open
+description: Open scene from the project asset file. Use 'assets-find' tool to find the scene asset first.
+---
+
+# Scene / Open
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-open --input '{
+  "sceneRef": "string_value",
+  "loadSceneMode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-open --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-open --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sceneRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `loadSceneMode` | `string` | No | Open scene mode. Single: closes the current scenes and opens a new one. Additive: keeps the current scene and opens additional one. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sceneRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "loadSceneMode": {
+      "type": "string",
+      "enum": [
+        "Single",
+        "Additive",
+        "AdditiveWithoutLoading"
+      ]
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "sceneRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-save/SKILL.md
+++ b/.claude/skills/scene-save/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: scene-save
+description: Save Opened scene to the asset file. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Save
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-save --input '{
+  "openedSceneName": "string_value",
+  "path": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-save --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-save --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `openedSceneName` | `string` | No | Name of the opened scene that should be saved. Could be empty if need to save the current active scene. |
+| `path` | `string` | No | Path to the scene file. Should end with ".unity". If null or empty save to the existed scene asset file. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "openedSceneName": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/scene-set-active/SKILL.md
+++ b/.claude/skills/scene-set-active/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: scene-set-active
+description: Set the specified opened scene as the active scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Set Active
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-set-active --input '{
+  "sceneRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-set-active --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-set-active --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sceneRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sceneRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "sceneRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/scene-unload/SKILL.md
+++ b/.claude/skills/scene-unload/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: scene-unload
+description: Unload scene from the Opened scenes in Unity Editor. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Unload
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-unload --input '{
+  "name": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-unload --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-unload --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | Name of the loaded scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Scene+UnloadSceneResult"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Scene+UnloadSceneResult": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name of the unloaded scene."
+        },
+        "AssetObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+          "description": "Reference to the unloaded scene asset."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/screenshot-camera/SKILL.md
+++ b/.claude/skills/screenshot-camera/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: screenshot-camera
+description: Captures a screenshot from a camera and returns it as an image. If no camera is specified, uses the Main Camera. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Camera
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-camera --input '{
+  "cameraRef": "string_value",
+  "width": 0,
+  "height": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-camera --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-camera --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cameraRef` | `any` | No | Reference to the camera GameObject. If not specified, uses the Main Camera. |
+| `width` | `integer` | No | Width of the screenshot in pixels. |
+| `height` | `integer` | No | Height of the screenshot in pixels. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "cameraRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "width": {
+      "type": "integer"
+    },
+    "height": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/screenshot-game-view/SKILL.md
+++ b/.claude/skills/screenshot-game-view/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: screenshot-game-view
+description: Captures a screenshot from the Unity Editor Game View and returns it as an image. Reads the Game View's own render texture directly via the Unity Editor API. The image size matches the current Game View resolution. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Game View
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-game-view --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-game-view --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-game-view --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/screenshot-scene-view/SKILL.md
+++ b/.claude/skills/screenshot-scene-view/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: screenshot-scene-view
+description: Captures a screenshot from the Unity Editor Scene View and returns it as an image. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Scene View
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-scene-view --input '{
+  "width": 0,
+  "height": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-scene-view --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-scene-view --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `width` | `integer` | No | Width of the screenshot in pixels. |
+| `height` | `integer` | No | Height of the screenshot in pixels. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "width": {
+      "type": "integer"
+    },
+    "height": {
+      "type": "integer"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/script-delete/SKILL.md
+++ b/.claude/skills/script-delete/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: script-delete
+description: Delete the script file(s). Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. Use 'script-read' tool to read existing script files first.
+---
+
+# Script / Delete
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-delete --input '{
+  "files": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-delete --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-delete --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `files` | `any` | Yes | File paths to the files. Sample: "Assets/Scripts/MyScript.cs". |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "files": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "files"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/script-execute/SKILL.md
+++ b/.claude/skills/script-execute/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: script-execute
+description: Compiles and executes C# code dynamically using Roslyn. The provided code must define a class with a static method to execute.
+---
+
+# Script / Execute
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-execute --input '{
+  "csharpCode": "string_value",
+  "className": "string_value",
+  "methodName": "string_value",
+  "parameters": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-execute --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-execute --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `csharpCode` | `string` | Yes | C# code that compiles and executes immediately. It won't be stored as a script in the project. It is temporary one shot C# code execution using Roslyn. IMPORTANT: The code must define a class (e.g., 'public class Script') with a static method (e.g., 'public static object Main()'). Do NOT use top-level statements or code outside a class. Top-level statements are not supported and will cause compilation errors. |
+| `className` | `string` | No | The name of the class containing the method to execute. |
+| `methodName` | `string` | No | The name of the method to execute. It must be a static method in the class provided above. |
+| `parameters` | `any` | No | Serialized parameters to pass to the method. If the method does not require parameters, leave this empty. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "csharpCode": {
+      "type": "string"
+    },
+    "className": {
+      "type": "string"
+    },
+    "methodName": {
+      "type": "string"
+    },
+    "parameters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "csharpCode"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/script-read/SKILL.md
+++ b/.claude/skills/script-read/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: script-read
+description: Reads the content of a script file and returns it as a string. Use 'script-update-or-create' tool to update or create script files.
+---
+
+# Script / Read
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-read --input '{
+  "filePath": "string_value",
+  "lineFrom": 0,
+  "lineTo": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-read --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-read --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filePath` | `string` | Yes | The path to the file. Sample: "Assets/Scripts/MyScript.cs". |
+| `lineFrom` | `integer` | No | The line number to start reading from (1-based). |
+| `lineTo` | `integer` | No | The line number to stop reading at (1-based, -1 for all lines). |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filePath": {
+      "type": "string"
+    },
+    "lineFrom": {
+      "type": "integer"
+    },
+    "lineTo": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "filePath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/script-update-or-create/SKILL.md
+++ b/.claude/skills/script-update-or-create/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: script-update-or-create
+description: Updates or creates script file with the provided C# code. Does AssetDatabase.Refresh() at the end. Provides compilation error details if the code has syntax errors. Use 'script-read' tool to read existing script files first.
+---
+
+# Script / Update or Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-update-or-create --input '{
+  "filePath": "string_value",
+  "content": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-update-or-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-update-or-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filePath` | `string` | Yes | The path to the file. Sample: "Assets/Scripts/MyScript.cs". |
+| `content` | `string` | Yes | C# code - content of the file. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filePath": {
+      "type": "string"
+    },
+    "content": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "filePath",
+    "content"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/tests-run/SKILL.md
+++ b/.claude/skills/tests-run/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: tests-run
+description: Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development.
+---
+
+# Tests / Run
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tests-run --input '{
+  "testMode": "string_value",
+  "testAssembly": "string_value",
+  "testNamespace": "string_value",
+  "testClass": "string_value",
+  "testMethod": "string_value",
+  "includePassingTests": false,
+  "includeMessages": false,
+  "includeStacktrace": false,
+  "includeLogs": false,
+  "logType": "string_value",
+  "includeLogsStacktrace": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tests-run --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tests-run --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `testMode` | `string` | No | Test mode to run. Options: 'EditMode', 'PlayMode'. Default: 'EditMode' |
+| `testAssembly` | `string` | No | Specific test assembly name to run (optional). Example: 'Assembly-CSharp-Editor-testable' |
+| `testNamespace` | `string` | No | Specific test namespace to run (optional). Example: 'MyTestNamespace' |
+| `testClass` | `string` | No | Specific test class name to run (optional). Example: 'MyTestClass' |
+| `testMethod` | `string` | No | Specific fully qualified test method to run (optional). Example: 'MyTestNamespace.FixtureName.TestName' |
+| `includePassingTests` | `boolean` | No | Include details for all tests, both passing and failing (default: false). If you just need details for failing tests, set to false. |
+| `includeMessages` | `boolean` | No | Include test result messages in the test results (default: true). If you just need pass/fail status, set to false. |
+| `includeStacktrace` | `boolean` | No | Include stack traces in the test results (default: false). |
+| `includeLogs` | `boolean` | No | Include console logs in the test results (default: false). |
+| `logType` | `string` | No | Log type filter for console logs. Options: 'Log', 'Warning', 'Assert', 'Error', 'Exception'. (default: 'Warning') |
+| `includeLogsStacktrace` | `boolean` | No | Include stack traces for console logs in the test results (default: false). This is huge amount of data, use only if really needed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "testMode": {
+      "type": "string",
+      "enum": [
+        "EditMode",
+        "PlayMode"
+      ]
+    },
+    "testAssembly": {
+      "type": "string"
+    },
+    "testNamespace": {
+      "type": "string"
+    },
+    "testClass": {
+      "type": "string"
+    },
+    "testMethod": {
+      "type": "string"
+    },
+    "includePassingTests": {
+      "type": "boolean"
+    },
+    "includeMessages": {
+      "type": "boolean"
+    },
+    "includeStacktrace": {
+      "type": "boolean"
+    },
+    "includeLogs": {
+      "type": "boolean"
+    },
+    "logType": {
+      "type": "string",
+      "enum": [
+        "Error",
+        "Assert",
+        "Warning",
+        "Log",
+        "Exception"
+      ]
+    },
+    "includeLogsStacktrace": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestRunResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestSummaryData": {
+      "type": "object",
+      "properties": {
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Unknown",
+            "Passed",
+            "Failed"
+          ]
+        },
+        "TotalTests": {
+          "type": "integer"
+        },
+        "PassedTests": {
+          "type": "integer"
+        },
+        "FailedTests": {
+          "type": "integer"
+        },
+        "SkippedTests": {
+          "type": "integer"
+        },
+        "Duration": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Status",
+        "TotalTests",
+        "PassedTests",
+        "FailedTests",
+        "SkippedTests",
+        "Duration"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Passed",
+            "Failed",
+            "Skipped"
+          ]
+        },
+        "Duration": {
+          "type": "string"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "StackTrace": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Status",
+        "Duration"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry": {
+      "type": "object",
+      "properties": {
+        "Condition": {
+          "type": "string"
+        },
+        "StackTrace": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Error",
+            "Assert",
+            "Warning",
+            "Log",
+            "Exception"
+          ]
+        },
+        "Timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "LogLevel": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Type",
+        "Timestamp"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestRunResponse": {
+      "type": "object",
+      "properties": {
+        "Summary": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestSummaryData",
+          "description": "Summary of the test run including total, passed, failed, and skipped counts."
+        },
+        "Results": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData>",
+          "description": "List of individual test results with details about each test."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry>",
+          "description": "Log entries captured during test execution."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/tool-list/SKILL.md
+++ b/.claude/skills/tool-list/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: tool-list
+description: List all available MCP tools. Optionally filter by regex across tool names, descriptions, and arguments.
+---
+
+# Tool / List
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tool-list --input '{
+  "regexSearch": "string_value",
+  "includeDescription": "string_value",
+  "includeInputs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tool-list --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tool-list --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `regexSearch` | `string` | No | Regex pattern to filter tools. Matches against tool name, description, and argument names and descriptions. |
+| `includeDescription` | `any` | No | Include tool descriptions in the result. Default: false |
+| `includeInputs` | `any` | No | Include input arguments in the result. Default: None |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "regexSearch": {
+      "type": "string"
+    },
+    "includeDescription": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeInputs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputRequest"
+    }
+  },
+  "$defs": {
+    "System.Boolean": {
+      "type": "boolean"
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputRequest": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Inputs",
+        "InputsWithDescription"
+      ],
+      "description": "Specifies what to include for tool input arguments."
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Tool name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Tool description."
+        },
+        "inputs": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData[]",
+          "description": "Tool input arguments."
+        }
+      },
+      "description": "MCP tool information."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData",
+        "description": "MCP tool input argument."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Argument name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Argument description."
+        }
+      },
+      "description": "MCP tool input argument."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData",
+        "description": "MCP tool information."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/tool-set-enabled-state/SKILL.md
+++ b/.claude/skills/tool-set-enabled-state/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: tool-set-enabled-state
+description: Enable or disable MCP tools by name. Allows controlling which tools are available for the AI agent.
+---
+
+# Tool / Set Enabled State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tool-set-enabled-state --input '{
+  "tools": "string_value",
+  "includeLogs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tool-set-enabled-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tool-set-enabled-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `tools` | `any` | Yes | Array of tools with their desired enabled state. |
+| `includeLogs` | `any` | No | Include operation logs in the result. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "tools": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData[]"
+    },
+    "includeLogs": {
+      "$ref": "#/$defs/System.Boolean"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name of the MCP tool to enable or disable."
+        },
+        "Enabled": {
+          "type": "boolean",
+          "description": "Whether the tool should be enabled (true) or disabled (false)."
+        }
+      },
+      "required": [
+        "Enabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData"
+      }
+    },
+    "System.Boolean": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "tools"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ResultData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.Logs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.LogEntry"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.LogEntry": {
+      "type": "object",
+      "properties": {
+        "Depth": {
+          "type": "integer"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Success",
+            "Warning",
+            "Error",
+            "Critical"
+          ]
+        }
+      },
+      "required": [
+        "Depth",
+        "Type"
+      ]
+    },
+    "System.Collections.Generic.Dictionary<System.String,System.Boolean>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ResultData": {
+      "type": "object",
+      "properties": {
+        "Logs": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.Logs",
+          "description": "Optional operation logs. Only included when 'includeLogs' is true."
+        },
+        "Success": {
+          "$ref": "#/$defs/System.Collections.Generic.Dictionary<System.String,System.Boolean>",
+          "description": "Result of each tool operation. Key: original input name as provided by the caller (case preserved as-is). Value: true if the enable/disable operation completed successfully, false if the name was unknown, ambiguous, or empty."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/type-get-json-schema/SKILL.md
+++ b/.claude/skills/type-get-json-schema/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: type-get-json-schema
+description: Generates a JSON Schema for a given C# type name using reflection. Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. The type must be present in any loaded assembly. Use the full type name (e.g. 'UnityEngine.Vector3') for best results.
+---
+
+# Type / Get Json Schema
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool type-get-json-schema --input '{
+  "typeName": "string_value",
+  "descriptionMode": "string_value",
+  "propertyDescriptionMode": "string_value",
+  "includeNestedTypes": false,
+  "writeIndented": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool type-get-json-schema --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool type-get-json-schema --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `typeName` | `string` | Yes | Full C# type name to generate the schema for. Examples: 'System.String', 'UnityEngine.Vector3', 'System.Collections.Generic.List<System.Int32>'. Simple names like 'Vector3' are also accepted when unambiguous. |
+| `descriptionMode` | `string` | No | Controls the type-level 'description' field. Include: keep on the target type only. IncludeRecursively: keep on the target type and inside $defs entries. Ignore: strip all type-level descriptions. Default: Ignore. |
+| `propertyDescriptionMode` | `string` | No | Controls 'description' fields on properties, fields, and array items. Include: keep on the target type's own properties/items only. IncludeRecursively: keep on all properties/items including those inside $defs entries. Ignore: strip all property/item descriptions. Default: Ignore. |
+| `includeNestedTypes` | `boolean` | No | When true, complex nested types are extracted into '$defs' and referenced via '$ref' instead of being inlined. Useful for large or recursive types. Default: false. |
+| `writeIndented` | `boolean` | No | Whether to format the output JSON with indentation for readability. Default: false. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "typeName": {
+      "type": "string"
+    },
+    "descriptionMode": {
+      "type": "string",
+      "enum": [
+        "Include",
+        "IncludeRecursively",
+        "Ignore"
+      ]
+    },
+    "propertyDescriptionMode": {
+      "type": "string",
+      "enum": [
+        "Include",
+        "IncludeRecursively",
+        "Ignore"
+      ]
+    },
+    "includeNestedTypes": {
+      "type": "boolean"
+    },
+    "writeIndented": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "typeName"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.claude/skills/unity-initial-setup/SKILL.md
+++ b/.claude/skills/unity-initial-setup/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: unity-initial-setup
+description: |-
+  Provides an initial setup for AI Skills, `unity-mcp-cli` command line tool installation
+  and everything else that is helpful to set up at the start of the project. Essential packages,
+  and basic configurations.
+---
+
+# AI Game Developer — Initial Setup
+
+This guide walks through installing the `unity-mcp-cli` command-line tool and using it to set
+up a Unity project with AI Skills and MCP integration.
+
+---
+
+## Prerequisites
+
+### Install Node.js
+
+`unity-mcp-cli` requires **Node.js ^20.19.0 || >=22.12.0** (Node 21.x is not supported). If you don't have Node.js installed:
+
+Download the installer from https://nodejs.org/ and run it, or use a package manager:
+```
+winget install OpenJS.NodeJS.LTS
+```
+
+After installation, verify both `node` and `npm` are available:
+```
+node --version
+npm --version
+```
+
+---
+
+## Install `unity-mcp-cli` Globally
+
+Install the CLI globally so the `unity-mcp-cli` command is available system-wide:
+
+```bash
+npm install -g unity-mcp-cli
+```
+
+Verify installation:
+```bash
+unity-mcp-cli --version
+```
+
+
+> **Alternative**: Run any command without installing globally using `npx`:
+> ```bash
+> npx unity-mcp-cli --help
+> ```
+
+---
+
+## Quick Start — Full Project Setup
+
+### 1. Install the Unity-MCP Plugin
+
+Add the plugin to an existing Unity project:
+```bash
+unity-mcp-cli install-plugin /path/to/unity/project
+```
+
+### 2. Configure MCP Tools
+
+Enable all tools, prompts, and resources:
+```bash
+unity-mcp-cli configure /path/to/unity/project \
+  --enable-all-tools \
+  --enable-all-prompts \
+  --enable-all-resources
+```
+
+### 3. Set Up MCP for Your AI Agent
+
+Configure MCP integration for your AI agent (e.g., Claude Code, Cursor, Copilot):
+```bash
+unity-mcp-cli setup-mcp claude-code /path/to/unity/project
+```
+
+List all supported agents:
+```bash
+unity-mcp-cli setup-mcp --list
+```
+
+### 4. Generate AI Skills
+
+Generate skill files for your AI agent (requires Unity Editor to be running with the plugin):
+```bash
+unity-mcp-cli setup-skills claude-code /path/to/unity/project
+```
+
+### 5. Open Unity with MCP Connection
+
+```bash
+unity-mcp-cli open /path/to/unity/project
+```
+
+---
+
+## Common Commands Reference
+
+| Command | Description |
+|---|---|
+| `unity-mcp-cli install-plugin <path>` | Install Unity-MCP plugin into a project |
+| `unity-mcp-cli remove-plugin <path>` | Remove Unity-MCP plugin from a project |
+| `unity-mcp-cli configure <path> --list` | List current MCP configuration |
+| `unity-mcp-cli setup-mcp <agent> <path>` | Write MCP config for an AI agent |
+| `unity-mcp-cli setup-skills <agent> <path>` | Generate skill files for an AI agent |
+| `unity-mcp-cli create-project <path>` | Create a new Unity project |
+| `unity-mcp-cli install-unity <version>` | Install a Unity Editor version |
+| `unity-mcp-cli open <path>` | Open a Unity project in the Editor |
+| `unity-mcp-cli run-tool <tool> <path>` | Execute an MCP tool via HTTP API |
+
+Add `--verbose` to any command for detailed diagnostic output.
+
+---
+
+## Troubleshooting
+
+- **`npm` not found**: Node.js is not installed or not in your PATH. Reinstall Node.js and restart your terminal.
+- **Plugin not appearing in Unity**: After `install-plugin`, open the project in Unity Editor. The package manager resolves dependencies on project open.
+- **Skills generation fails**: Ensure Unity Editor is running with the MCP plugin installed and connected before running `setup-skills`.

--- a/.claude/skills/unity-skill-create/SKILL.md
+++ b/.claude/skills/unity-skill-create/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: unity-skill-create
+description: |-
+  Create a new skill using C# code. It will be added into the project as a .cs file and compiled by Unity. The skill will be available for use after compilation.
+  
+  It must be a partial class decorated with [McpPluginToolType]. Each tool method must be decorated with [McpPluginTool]. The class name should match the file name. All Unity API calls must use com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(). Return a data model for structured output, or void for side-effect-only operations. 
+  
+  Full sample:
+  ```csharp
+  #nullable enable
+  using System;
+  using System.ComponentModel;
+  using com.IvanMurzak.McpPlugin;
+  using com.IvanMurzak.ReflectorNet.Utils;
+  using com.IvanMurzak.Unity.MCP.Editor.Utils;
+  using com.IvanMurzak.Unity.MCP.Runtime.Data;
+  using UnityEditor;
+  using UnityEngine;
+  
+  namespace com.IvanMurzak.Unity.MCP.Editor.API
+  {
+      [McpPluginToolType]
+      public partial class Tool_Sample
+      {
+          [McpPluginTool("sample-get", Title = "Sample / Get")]
+          [Description("Finds a GameObject and returns its ref data.")]
+          public GameObjectRef Get
+          (
+              [Description("Name of the GameObject to find.")]
+              string name
+          )
+          {
+              return MainThread.Instance.Run(() =>
+              {
+                  var go = GameObject.Find(name)
+                      ?? throw new ArgumentException($"GameObject '{name}' not found.", nameof(name));
+  
+                  return new GameObjectRef(go);
+              });
+          }
+  
+          [McpPluginTool("sample-rename", Title = "Sample / Rename")]
+          [Description("Renames a GameObject.")]
+          public void Rename
+          (
+              [Description("Current name of the GameObject.")]
+              string name,
+              [Description("New name to assign.")]
+              string newName
+          )
+          {
+              MainThread.Instance.Run(() =>
+              {
+                  var go = GameObject.Find(name)
+                      ?? throw new ArgumentException($"GameObject '{name}' not found.", nameof(name));
+  
+                  go.name = newName;
+                  EditorUtility.SetDirty(go);
+                  AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+                  EditorUtils.RepaintAllEditorWindows();
+              });
+          }
+      }
+  }
+  ```
+  ## Suggestions
+  
+  ### Refresh UI after visual changes
+  If the skill modifies anything visually in the Unity Editor (GameObjects, components, materials, etc.), call these two lines at the end of the tool method to apply changes to the UI immediately:
+  ```csharp
+  AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+  EditorUtils.RepaintAllEditorWindows();
+  ```
+  
+  ### Refresh AssetDatabase after asset or script changes
+  If the skill creates, modifies, or deletes any asset file or .cs script on disk outside of Unity API, call this inside a `MainThread.Instance.Run()` block to ensure Unity picks up the changes:
+  ```csharp
+  MainThread.Instance.Run(() =>
+  {
+      AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+  });
+  ```
+  
+  ### Use processing mechanic for long-running or domain-reload operations
+  Some operations take time to complete and may trigger a Unity domain reload (e.g. writing a .cs script, switching play mode, running tests, adding a package). In these cases the tool must NOT block and wait — instead it must:
+  1. Accept a `[RequestID] string? requestId` parameter.
+  2. Return `ResponseCallTool.Processing("...").SetRequestID(requestId)` immediately.
+  3. Schedule the actual work asynchronously via `MainThread.Instance.RunAsync(async () => { await Task.Yield(); ... })`.
+  4. When the operation finishes, send the final result by calling:
+  ```csharp
+  _ = UnityMcpPluginEditor.NotifyToolRequestCompleted(new RequestToolCompletedData
+  {
+      RequestId = requestId,
+      Result = ResponseCallTool.Success("Operation completed.").SetRequestID(requestId)
+  });
+  ```
+  If the operation may survive a domain reload (e.g. a .cs file was saved and Unity will recompile), use `ScriptUtils.SchedulePostCompilationNotification(requestId, filePath, operationType)` instead of calling `NotifyToolRequestCompleted` directly — it persists the pending notification to `SessionState` and sends it automatically after the domain reload completes. For package install/removal or other non-compilation domain reloads use `PackageUtils.SchedulePostDomainReloadNotification(requestId, label, action, expectedResult)` the same way.
+  
+  ### Return structured data with a typed response
+  Prefer returning a structured data model over a plain string so the AI can parse individual fields. Declare a nested class with `[Description]` on each property and use `ResponseCallValueTool<T>` as return type:
+  ```csharp
+  // Return type:
+  public ResponseCallValueTool<MyResult> MyTool(...)
+  {
+      return ResponseCallValueTool<MyResult>.Success(new MyResult
+      {
+          Name = go.name,
+          InstanceID = go.GetInstanceID()
+      }).SetRequestID(requestId);
+  }
+  
+  // Data model:
+  public class MyResult
+  {
+      [Description("Name of the GameObject.")]
+      public string? Name { get; set; }
+  
+      [Description("Unity instance ID of the GameObject.")]
+      public int InstanceID { get; set; }
+  }
+  ```
+  For simpler cases that do not need async/processing, you may return the model directly (without `ResponseCallValueTool<T>`) and Unity-MCP will wrap it automatically.
+  
+  ### Validate inputs early and throw clearly
+  Always validate required parameters at the top of the method before any Unity API calls. Throw `ArgumentException` or `InvalidOperationException` with descriptive messages so the AI knows exactly what went wrong and can self-correct:
+  ```csharp
+  if (string.IsNullOrEmpty(name))
+      throw new ArgumentException("Name cannot be null or empty.", nameof(name));
+  ```
+  
+  ### Always use MainThread for Unity API calls
+  All Unity API calls (including `GameObject.Find`, `AssetDatabase`, `EditorUtility`, etc.) MUST run on the main thread. Wrap them in `MainThread.Instance.Run(() => { ... })` for synchronous operations, or `MainThread.Instance.RunAsync(async () => { ... })` when you need to await inside.
+---
+
+# Skill (Tool) / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool unity-skill-create --input '{
+  "path": "string_value",
+  "code": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Yes | Path for the C# (.cs) file to be created. Sample: "Assets/Skills/MySkill.cs".
+CRITICAL — Assembly Definition placement: If the project uses Assembly Definition files (.asmdef), you MUST place the script inside a folder that belongs to an assembly definition which already references all required dependencies (e.g. com.IvanMurzak.McpPlugin, UnityEditor, UnityEngine). Placing the file in the wrong assembly will cause compile errors due to missing type references. Before choosing a path, inspect existing .asmdef files with the assets-find tool to identify the correct assembly folder. |
+| `code` | `string` | Yes | C# code for the skill tool. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "code": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "path",
+    "code"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.claude/skills/unity-skill-generate/SKILL.md
+++ b/.claude/skills/unity-skill-generate/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: unity-skill-generate
+description: Generate all skills from the existed Tools in the Unity Project.
+---
+
+# Skill (Tool) / Generate All
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool unity-skill-generate --input '{
+  "path": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-generate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-generate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | No | Path to the skills folder. If null or empty, the default path will be used. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "ai-game-developer": {
+      "headers": {
+        "Authorization": "Bearer g1YAw9KEALiguBQwEmIMXt3Dom6ZMFC3MLUVokzBPtU"
+      },
+      "type": "http",
+      "url": "https://ai-game.dev/mcp"
+    }
+  }
+}

--- a/.gemini/skills/animation-create/SKILL.md
+++ b/.gemini/skills/animation-create/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: animation-create
+description: Create Unity's Animation asset files (AnimationClip). Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.anim'.
+---
+
+# Animation / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-create --input '{
+  "sourcePaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the animation assets to create. Each path should start with 'Assets/' and end with '.anim'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreateAnimationResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreateAnimationResponse": {
+      "type": "object",
+      "properties": {
+        "createdAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CreatedAnimationInfo>"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/animation-get-data/SKILL.md
+++ b/.gemini/skills/animation-get-data/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: animation-get-data
+description: Get data about a Unity AnimationClip asset file. Returns information such as name, length, frame rate, wrap mode, animation curves, and events.
+---
+
+# Animation / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-get-data --input '{
+  "animRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animRef` | `any` | Yes | Reference to the animation asset. The path should start with 'Assets/' and end with '.anim'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "animRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+GetDataResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "isPPtrCurve": {
+          "type": "boolean"
+        },
+        "isDiscreteCurve": {
+          "type": "boolean"
+        },
+        "keyframeCount": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "isPPtrCurve",
+        "isDiscreteCurve",
+        "keyframeCount"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo": {
+      "type": "object",
+      "properties": {
+        "time": {
+          "type": "number"
+        },
+        "functionName": {
+          "type": "string"
+        },
+        "intParameter": {
+          "type": "integer"
+        },
+        "floatParameter": {
+          "type": "number"
+        },
+        "stringParameter": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "time",
+        "intParameter",
+        "floatParameter"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+GetDataResponse": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number"
+        },
+        "frameRate": {
+          "type": "number"
+        },
+        "wrapMode": {
+          "type": "string"
+        },
+        "isLooping": {
+          "type": "boolean"
+        },
+        "hasGenericRootTransform": {
+          "type": "boolean"
+        },
+        "hasMotionCurves": {
+          "type": "boolean"
+        },
+        "hasMotionFloatCurves": {
+          "type": "boolean"
+        },
+        "hasRootCurves": {
+          "type": "boolean"
+        },
+        "humanMotion": {
+          "type": "boolean"
+        },
+        "legacy": {
+          "type": "boolean"
+        },
+        "localBounds": {
+          "type": "string"
+        },
+        "empty": {
+          "type": "boolean"
+        },
+        "curveBindings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>"
+        },
+        "objectReferenceBindings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+CurveBindingInfo>"
+        },
+        "events": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimationTools+AnimationEventInfo>"
+        }
+      },
+      "required": [
+        "length",
+        "frameRate",
+        "isLooping",
+        "hasGenericRootTransform",
+        "hasMotionCurves",
+        "hasMotionFloatCurves",
+        "hasRootCurves",
+        "humanMotion",
+        "legacy",
+        "empty"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/animation-modify/SKILL.md
+++ b/.gemini/skills/animation-modify/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: animation-modify
+description: Modify Unity's AnimationClip asset. Apply an array of modifications including setting curves, clearing curves, setting properties, and managing animation events. Use 'animation-get-data' tool to get valid property names and existing curves for modifications.
+---
+
+# Animation / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animation-modify --input '{
+  "animRef": "string_value",
+  "modifications": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animation-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animation-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animRef` | `any` | Yes | Reference to the AnimationClip asset to modify. |
+| `modifications` | `any` | Yes | Array of modifications to apply to the clip. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "modifications": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationModification[]"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationModification": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "SetCurve",
+            "RemoveCurve",
+            "ClearCurves",
+            "SetFrameRate",
+            "SetWrapMode",
+            "SetLegacy",
+            "AddEvent",
+            "ClearEvents"
+          ],
+          "description": "Modification type. Properties below are used conditionally based on this value."
+        },
+        "relativePath": {
+          "type": "string",
+          "description": "Path to target GameObject relative to the root (empty for root). Used by: SetCurve, RemoveCurve."
+        },
+        "componentType": {
+          "type": "string",
+          "description": "Component type name (e.g., 'Transform', 'SpriteRenderer'). Required for: SetCurve, RemoveCurve."
+        },
+        "propertyName": {
+          "type": "string",
+          "description": "Property to animate (e.g., 'localPosition.x', 'm_LocalScale.y'). Required for: SetCurve, RemoveCurve."
+        },
+        "keyframes": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe[]",
+          "description": "Keyframes for the curve. Required for: SetCurve."
+        },
+        "frameRate": {
+          "type": "number",
+          "description": "Frames per second. Required for: SetFrameRate."
+        },
+        "wrapMode": {
+          "type": "string",
+          "enum": [
+            "Default",
+            "Clamp",
+            "Clamp",
+            "Loop",
+            "PingPong",
+            "ClampForever"
+          ],
+          "description": "How animation behaves at boundaries. Required for: SetWrapMode."
+        },
+        "legacy": {
+          "type": "boolean",
+          "description": "Use legacy animation system. Required for: SetLegacy."
+        },
+        "time": {
+          "type": "number",
+          "description": "Event trigger time in seconds. Required for: AddEvent."
+        },
+        "functionName": {
+          "type": "string",
+          "description": "Function to invoke. Required for: AddEvent."
+        },
+        "stringParameter": {
+          "type": "string",
+          "description": "String parameter passed to the function. Optional for: AddEvent."
+        },
+        "floatParameter": {
+          "type": "number",
+          "description": "Float parameter passed to the function. Optional for: AddEvent."
+        },
+        "intParameter": {
+          "type": "integer",
+          "description": "Integer parameter passed to the function. Optional for: AddEvent."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationKeyframe": {
+      "type": "object",
+      "properties": {
+        "time": {
+          "type": "number",
+          "description": "Time in seconds."
+        },
+        "value": {
+          "type": "number",
+          "description": "Value at this keyframe."
+        },
+        "inTangent": {
+          "type": "number",
+          "description": "Incoming tangent (slope). Default: 0."
+        },
+        "outTangent": {
+          "type": "number",
+          "description": "Outgoing tangent (slope). Default: 0."
+        },
+        "weightedMode": {
+          "type": "string",
+          "enum": [
+            "None",
+            "In",
+            "Out",
+            "Both"
+          ],
+          "description": "Weighted mode: None (0), In (1), Out (2), Both (3). Default: None."
+        },
+        "inWeight": {
+          "type": "number",
+          "description": "Incoming weight. Default: 0.33."
+        },
+        "outWeight": {
+          "type": "number",
+          "description": "Outgoing weight. Default: 0.33."
+        }
+      },
+      "required": [
+        "time",
+        "value"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationModification[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationModification"
+      }
+    }
+  },
+  "required": [
+    "animRef",
+    "modifications"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationResponse": {
+      "type": "object",
+      "properties": {
+        "modifiedAsset": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimationTools+ModifyAnimationInfo"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/animator-create/SKILL.md
+++ b/.gemini/skills/animator-create/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: animator-create
+description: Create Unity's AnimatorController asset files. Creates folders recursively if they do not exist. Each path should start with 'Assets/' and end with '.controller'.
+---
+
+# Animator / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-create --input '{
+  "sourcePaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the animator controller assets to create. Each path should start with 'Assets/' and end with '.controller'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreateAnimatorResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreateAnimatorResponse": {
+      "type": "object",
+      "properties": {
+        "createdAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+CreatedAnimatorInfo>"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/animator-get-data/SKILL.md
+++ b/.gemini/skills/animator-get-data/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: animator-get-data
+description: Get data about a Unity AnimatorController asset file. Returns information such as name, layers, parameters, and states.
+---
+
+# Animator / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-get-data --input '{
+  "animatorRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animatorRef` | `any` | Yes | Reference to the AnimatorController asset. The path should start with 'Assets/' and end with '.controller'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animatorRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "animatorRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+GetAnimatorDataResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "defaultFloat": {
+          "type": "number"
+        },
+        "defaultInt": {
+          "type": "integer"
+        },
+        "defaultBool": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "defaultFloat",
+        "defaultInt",
+        "defaultBool"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "defaultWeight": {
+          "type": "number"
+        },
+        "blendingMode": {
+          "type": "string"
+        },
+        "syncedLayerIndex": {
+          "type": "integer"
+        },
+        "iKPass": {
+          "type": "boolean"
+        },
+        "defaultStateName": {
+          "type": "string"
+        },
+        "states": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo>"
+        },
+        "subStateMachines": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        },
+        "anyStateTransitions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>"
+        }
+      },
+      "required": [
+        "defaultWeight",
+        "syncedLayerIndex",
+        "iKPass"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorStateInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "speed": {
+          "type": "number"
+        },
+        "speedParameterActive": {
+          "type": "boolean"
+        },
+        "speedParameter": {
+          "type": "string"
+        },
+        "cycleOffset": {
+          "type": "number"
+        },
+        "cycleOffsetParameterActive": {
+          "type": "boolean"
+        },
+        "cycleOffsetParameter": {
+          "type": "string"
+        },
+        "mirror": {
+          "type": "boolean"
+        },
+        "mirrorParameterActive": {
+          "type": "boolean"
+        },
+        "mirrorParameter": {
+          "type": "string"
+        },
+        "writeDefaultValues": {
+          "type": "boolean"
+        },
+        "motionName": {
+          "type": "string"
+        },
+        "transitions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>"
+        }
+      },
+      "required": [
+        "speed",
+        "speedParameterActive",
+        "cycleOffset",
+        "cycleOffsetParameterActive",
+        "mirror",
+        "mirrorParameterActive",
+        "writeDefaultValues"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTransitionInfo": {
+      "type": "object",
+      "properties": {
+        "destinationStateName": {
+          "type": "string"
+        },
+        "hasExitTime": {
+          "type": "boolean"
+        },
+        "exitTime": {
+          "type": "number"
+        },
+        "hasFixedDuration": {
+          "type": "boolean"
+        },
+        "duration": {
+          "type": "number"
+        },
+        "offset": {
+          "type": "number"
+        },
+        "canTransitionToSelf": {
+          "type": "boolean"
+        },
+        "conditions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo>"
+        }
+      },
+      "required": [
+        "hasExitTime",
+        "exitTime",
+        "hasFixedDuration",
+        "duration",
+        "offset",
+        "canTransitionToSelf"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionInfo": {
+      "type": "object",
+      "properties": {
+        "parameter": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "threshold"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+GetAnimatorDataResponse": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorParameterInfo>"
+        },
+        "layers": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Animation.AnimatorLayerInfo>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/animator-modify/SKILL.md
+++ b/.gemini/skills/animator-modify/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: animator-modify
+description: Modify Unity's AnimatorController asset. Apply an array of modifications including adding/removing parameters, layers, states, and transitions. Use 'animator-get-data' tool to get valid names and parameters for modifications.
+---
+
+# Animator / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool animator-modify --input '{
+  "animatorRef": "string_value",
+  "modifications": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool animator-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool animator-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `animatorRef` | `any` | Yes | Reference to the AnimatorController asset to modify. |
+| `modifications` | `any` | Yes | Array of modifications to apply to the controller. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "animatorRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "modifications": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorModification[]"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorModification": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "AddParameter",
+            "RemoveParameter",
+            "AddLayer",
+            "RemoveLayer",
+            "AddState",
+            "RemoveState",
+            "SetDefaultState",
+            "AddTransition",
+            "RemoveTransition",
+            "AddAnyStateTransition",
+            "SetStateMotion",
+            "SetStateSpeed"
+          ],
+          "description": "Modification type. Properties below are used conditionally based on this value."
+        },
+        "parameterName": {
+          "type": "string",
+          "description": "Parameter name. Required for: AddParameter, RemoveParameter."
+        },
+        "parameterType": {
+          "type": "string",
+          "description": "Parameter type: Float, Int, Bool, Trigger. Required for: AddParameter."
+        },
+        "defaultFloat": {
+          "type": "number",
+          "description": "Default float value. Optional for: AddParameter (Float type)."
+        },
+        "defaultInt": {
+          "type": "integer",
+          "description": "Default int value. Optional for: AddParameter (Int type)."
+        },
+        "defaultBool": {
+          "type": "boolean",
+          "description": "Default bool value. Optional for: AddParameter (Bool type)."
+        },
+        "layerName": {
+          "type": "string",
+          "description": "Layer name. Required for: AddLayer, RemoveLayer, AddState, RemoveState, SetDefaultState, AddTransition, RemoveTransition, AddAnyStateTransition, SetStateMotion, SetStateSpeed."
+        },
+        "stateName": {
+          "type": "string",
+          "description": "State name. Required for: AddState, RemoveState, SetDefaultState, SetStateMotion, SetStateSpeed."
+        },
+        "motionAssetPath": {
+          "type": "string",
+          "description": "Asset path to AnimationClip. Optional for: AddState. Required for: SetStateMotion."
+        },
+        "speed": {
+          "type": "number",
+          "description": "Speed multiplier. Required for: SetStateSpeed."
+        },
+        "sourceStateName": {
+          "type": "string",
+          "description": "Source state name. Required for: AddTransition, RemoveTransition."
+        },
+        "destinationStateName": {
+          "type": "string",
+          "description": "Destination state name. Required for: AddTransition, RemoveTransition, AddAnyStateTransition."
+        },
+        "hasExitTime": {
+          "type": "boolean",
+          "description": "Whether transition waits for exit time. Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "exitTime": {
+          "type": "number",
+          "description": "Normalized exit time (0-1). Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "duration": {
+          "type": "number",
+          "description": "Transition blend duration. Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "hasFixedDuration": {
+          "type": "boolean",
+          "description": "Whether duration is in seconds (true) or normalized (false). Optional for: AddTransition, AddAnyStateTransition."
+        },
+        "conditions": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData[]",
+          "description": "Transition conditions. Optional for: AddTransition, AddAnyStateTransition."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorConditionData": {
+      "type": "object",
+      "properties": {
+        "parameter": {
+          "type": "string",
+          "description": "Parameter name for the condition."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Condition mode: If, IfNot, Greater, Less, Equals, NotEqual."
+        },
+        "threshold": {
+          "type": "number",
+          "description": "Threshold value for the condition."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorModification[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorModification"
+      }
+    }
+  },
+  "required": [
+    "animatorRef",
+    "modifications"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+ModifyAnimatorResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Animation.ModifyAnimatorInfo": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "instanceId": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "instanceId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Animation.AnimatorTools+ModifyAnimatorResponse": {
+      "type": "object",
+      "properties": {
+        "modifiedAsset": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Animation.ModifyAnimatorInfo"
+        },
+        "errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>"
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-copy/SKILL.md
+++ b/.gemini/skills/assets-copy/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: assets-copy
+description: Copy assets at given paths and store them at new paths. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before copying.
+---
+
+# Assets / Copy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-copy --input '{
+  "sourcePaths": "string_value",
+  "destinationPaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-copy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-copy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the assets to copy. |
+| `destinationPaths` | `any` | Yes | The paths to store the copied assets. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "destinationPaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths",
+    "destinationPaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CopyAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CopyAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "CopiedAssets": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>",
+          "description": "List of copied assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during copy operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-create-folder/SKILL.md
+++ b/.gemini/skills/assets-create-folder/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: assets-create-folder
+description: Creates a new folder in the specified parent folder. The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end. Returns the GUID of the newly created folder, if successful.
+---
+
+# Assets / Create Folder
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-create-folder --input '{
+  "inputs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-create-folder --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-create-folder --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `inputs` | `any` | Yes | The paths for the folders to create. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "inputs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput": {
+      "type": "object",
+      "properties": {
+        "ParentFolderPath": {
+          "type": "string",
+          "description": "The parent folder path where the new folder will be created."
+        },
+        "NewFolderName": {
+          "type": "string",
+          "description": "The name of the new folder to create."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderInput"
+      }
+    }
+  },
+  "required": [
+    "inputs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+CreateFolderResponse": {
+      "type": "object",
+      "properties": {
+        "CreatedFolderGuids": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of GUIDs of created folders."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during folder creation."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-delete/SKILL.md
+++ b/.gemini/skills/assets-delete/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: assets-delete
+description: Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before deleting.
+---
+
+# Assets / Delete
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-delete --input '{
+  "paths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-delete --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-delete --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `paths` | `any` | Yes | The paths of the assets |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "paths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "paths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+DeleteAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+DeleteAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "DeletedPaths": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of paths of deleted assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during delete operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-find-built-in/SKILL.md
+++ b/.gemini/skills/assets-find-built-in/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: assets-find-built-in
+description: "Search the built-in assets of the Unity Editor located in the built-in resources: Resources/unity_builtin_extra. Doesn't support GUIDs since built-in assets do not have them."
+---
+
+# Assets / Find (Built-in)
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-find-built-in --input '{
+  "name": "string_value",
+  "type": "string_value",
+  "maxResults": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-find-built-in --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-find-built-in --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | No | The name of the asset to filter by. |
+| `type` | `any` | No | The type of the asset to filter by. |
+| `maxResults` | `integer` | No | Maximum number of assets to return. If the number of found assets exceeds this limit, the result will be truncated. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "$ref": "#/$defs/System.Type"
+    },
+    "maxResults": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-find/SKILL.md
+++ b/.gemini/skills/assets-find/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: assets-find
+description: Search the asset database using the search filter string. Allows you to search for Assets. The string argument can provide names, labels or types (classnames).
+---
+
+# Assets / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-find --input '{
+  "filter": "string_value",
+  "searchInFolders": "string_value",
+  "maxResults": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `string` | No | The filter string can contain search data. Could be empty. Name: Filter assets by their filename (without extension). Words separated by whitespace are treated as separate name searches. Labels (l:): Assets can have labels attached to them. Use 'l:' before each label. Types (t:): Find assets based on explicitly identified types. Use 't:' keyword. Available types: AnimationClip, AudioClip, AudioMixer, ComputeShader, Font, GUISkin, Material, Mesh, Model, PhysicMaterial, Prefab, Scene, Script, Shader, Sprite, Texture, VideoClip, VisualEffectAsset, VisualEffectSubgraph. AssetBundles (b:): Find assets which are part of an Asset bundle. Area (a:): Find assets in a specific area. Valid values are 'all', 'assets', and 'packages'. Globbing (glob:): Use globbing to match specific rules. Note: Searching is case insensitive. |
+| `searchInFolders` | `any` | No | The folders where the search will start. If null, the search will be performed in all folders. |
+| `maxResults` | `integer` | No | Maximum number of assets to return. If the number of found assets exceeds this limit, the result will be truncated. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "type": "string"
+    },
+    "searchInFolders": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "maxResults": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+        "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-get-data/SKILL.md
+++ b/.gemini/skills/assets-get-data/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: assets-get-data
+description: Get asset data from the asset file in the Unity project. It includes all serializable fields and properties of the asset. Use 'assets-find' tool to find asset before using this tool.
+---
+
+# Assets / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-get-data --input '{
+  "assetRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "assetRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-material-create/SKILL.md
+++ b/.gemini/skills/assets-material-create/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: assets-material-create
+description: Create new material asset with default parameters. Creates folders recursively if they do not exist. Provide proper 'shaderName' - use 'assets-shader-list-all' tool to find available shaders.
+---
+
+# Assets / Create Material
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-material-create --input '{
+  "assetPath": "string_value",
+  "shaderName": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-material-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-material-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetPath` | `string` | Yes | Asset path. Starts with 'Assets/'. Ends with '.mat'. |
+| `shaderName` | `string` | Yes | Name of the shader that need to be used to create the material. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetPath": {
+      "type": "string"
+    },
+    "shaderName": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "assetPath",
+    "shaderName"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-modify/SKILL.md
+++ b/.gemini/skills/assets-modify/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: assets-modify
+description: Modify asset file in the project. Use 'assets-get-data' tool first to inspect the asset structure before modifying. Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.
+---
+
+# Assets / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-modify --input '{
+  "assetRef": "string_value",
+  "content": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `content` | `any` | Yes | The asset content. It overrides the existing asset content. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "content": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "assetRef",
+    "content"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-move/SKILL.md
+++ b/.gemini/skills/assets-move/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: assets-move
+description: Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before moving.
+---
+
+# Assets / Move
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-move --input '{
+  "sourcePaths": "string_value",
+  "destinationPaths": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-move --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-move --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourcePaths` | `any` | Yes | The paths of the assets to move. |
+| `destinationPaths` | `any` | Yes | The paths of moved assets. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourcePaths": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "destinationPaths": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "sourcePaths",
+    "destinationPaths"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+MoveAssetsResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets+MoveAssetsResponse": {
+      "type": "object",
+      "properties": {
+        "MovedPaths": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of destination paths of successfully moved assets."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during move operations."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-prefab-close/SKILL.md
+++ b/.gemini/skills/assets-prefab-close/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assets-prefab-close
+description: Close currently opened prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+---
+
+# Assets / Prefab / Close
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-close --input '{
+  "save": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-close --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-close --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `save` | `boolean` | No | True to save prefab. False to discard changes. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "save": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-prefab-create/SKILL.md
+++ b/.gemini/skills/assets-prefab-create/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: assets-prefab-create
+description: Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Creates folders recursively if they do not exist. If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. Use 'gameobject-find' tool to find the target GameObject first.
+---
+
+# Assets / Prefab / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-create --input '{
+  "prefabAssetPath": "string_value",
+  "gameObjectRef": "string_value",
+  "sourcePrefabAssetPath": "string_value",
+  "connectGameObjectToPrefab": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefabAssetPath` | `string` | Yes | Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'. |
+| `gameObjectRef` | `any` | No | Reference to a scene GameObject to create the prefab from. If the GameObject is already a prefab instance, a Prefab Variant is created when 'connectGameObjectToPrefab' is true. Optional if 'sourcePrefabAssetPath' is provided. |
+| `sourcePrefabAssetPath` | `string` | No | Path to an existing prefab asset to create a Prefab Variant from (e.g. 'Assets/Prefabs/Base.prefab'). When provided, a temporary instance is created, saved as a Prefab Variant, and cleaned up. Optional if 'gameObjectRef' is provided. |
+| `connectGameObjectToPrefab` | `boolean` | No | If true, the scene GameObject will be connected to the new prefab (becoming a prefab instance). If the source is already a prefab instance, this creates a Prefab Variant. If false, the prefab asset is created but the scene GameObject remains unchanged. Ignored when 'sourcePrefabAssetPath' is used (always creates a variant). |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "prefabAssetPath": {
+      "type": "string"
+    },
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "sourcePrefabAssetPath": {
+      "type": "string"
+    },
+    "connectGameObjectToPrefab": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "prefabAssetPath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-prefab-instantiate/SKILL.md
+++ b/.gemini/skills/assets-prefab-instantiate/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: assets-prefab-instantiate
+description: Instantiates prefab in the current active scene. Use 'assets-find' tool to find prefab assets in the project.
+---
+
+# Assets / Prefab / Instantiate
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-instantiate --input '{
+  "prefabAssetPath": "string_value",
+  "gameObjectPath": "string_value",
+  "position": "string_value",
+  "rotation": "string_value",
+  "scale": "string_value",
+  "isLocalSpace": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-instantiate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-instantiate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prefabAssetPath` | `string` | Yes | Prefab asset path. |
+| `gameObjectPath` | `string` | Yes | GameObject path in the current active scene. |
+| `position` | `any` | No | Transform position of the GameObject. |
+| `rotation` | `any` | No | Transform rotation of the GameObject. Euler angles in degrees. |
+| `scale` | `any` | No | Transform scale of the GameObject. |
+| `isLocalSpace` | `boolean` | No | World or Local space of transform. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "prefabAssetPath": {
+      "type": "string"
+    },
+    "gameObjectPath": {
+      "type": "string"
+    },
+    "position": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "rotation": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "scale": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "isLocalSpace": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "UnityEngine.Vector3": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "prefabAssetPath",
+    "gameObjectPath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-prefab-open/SKILL.md
+++ b/.gemini/skills/assets-prefab-open/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: assets-prefab-open
+description: "Open prefab edit mode for a specific GameObject. In the Edit mode you can modify the prefab. The modification will be applied to all instances of the prefab across the project. Note: Please use 'assets-prefab-close' tool later to exit prefab editing mode."
+---
+
+# Assets / Prefab / Open
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-open --input '{
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-open --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-open --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | GameObject that represents prefab instance of an original prefab GameObject. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/assets-prefab-save/SKILL.md
+++ b/.gemini/skills/assets-prefab-save/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assets-prefab-save
+description: Save a prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+---
+
+# Assets / Prefab / Save
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-prefab-save --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-save --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-prefab-save --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-refresh/SKILL.md
+++ b/.gemini/skills/assets-refresh/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: assets-refresh
+description: Refreshes the AssetDatabase. Use it if any file was added or updated in the project outside of Unity API. Use it if need to force scripts recompilation when '.cs' file changed.
+---
+
+# Assets / Refresh
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-refresh --input '{
+  "options": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-refresh --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-refresh --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `options` | `any` | No | Asset import options. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "options": {
+      "$ref": "#/$defs/UnityEditor.ImportAssetOptions"
+    }
+  },
+  "$defs": {
+    "UnityEditor.ImportAssetOptions": {
+      "type": "string",
+      "enum": [
+        "Default",
+        "ForceUpdate",
+        "ForceSynchronousImport",
+        "ImportRecursive",
+        "DontDownloadFromCacheServer",
+        "ForceUncompressedImport"
+      ]
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/assets-shader-get-data/SKILL.md
+++ b/.gemini/skills/assets-shader-get-data/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: assets-shader-get-data
+description: "Get detailed data about a shader asset in the Unity project. Returns shader properties, subshaders, passes, compilation errors, and supported status. Use 'assets-find' tool with filter 't:Shader' to find shaders, or 'assets-shader-list-all' tool to list all shader names."
+---
+
+# Assets / Shader / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-shader-get-data --input '{
+  "assetRef": "string_value",
+  "includeMessages": "string_value",
+  "includeProperties": "string_value",
+  "includeSubshaders": "string_value",
+  "includeSourceCode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-shader-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-shader-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assetRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `includeMessages` | `any` | No | Include compilation error and warning messages. Default: true |
+| `includeProperties` | `any` | No | Include shader properties (uniforms) list. Default: false |
+| `includeSubshaders` | `any` | No | Include subshader and pass structure. Default: false |
+| `includeSourceCode` | `any` | No | Include pass source code in subshader data. Requires 'includeSubshaders' to be true. Can produce very large responses. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "assetRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "includeMessages": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeProperties": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeSubshaders": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeSourceCode": {
+      "$ref": "#/$defs/System.Boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Boolean": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "assetRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData": {
+      "type": "object",
+      "properties": {
+        "Message": {
+          "type": "string",
+          "description": "The error or warning message text."
+        },
+        "Line": {
+          "type": "integer",
+          "description": "The line number in the shader source where the issue occurs."
+        },
+        "Severity": {
+          "type": "string",
+          "description": "Severity level (e.g. 'Error', 'Warning')."
+        },
+        "Platform": {
+          "type": "string",
+          "description": "The platform on which the error occurs (e.g. 'OpenGLCore', 'D3D11')."
+        }
+      },
+      "required": [
+        "Line"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Property name as used in shader code (e.g. '_MainTex', '_Color')."
+        },
+        "Description": {
+          "type": "string",
+          "description": "Human-readable description/display name of the property."
+        },
+        "Type": {
+          "type": "string",
+          "description": "Property type (e.g. 'Color', 'Float', 'Range', 'Texture', 'Vector', 'Int')."
+        },
+        "Flags": {
+          "type": "string",
+          "description": "Property flags (e.g. 'None', 'HideInInspector', 'PerRendererData')."
+        },
+        "NameId": {
+          "type": "integer",
+          "description": "The unique name ID for this property."
+        },
+        "RangeMin": {
+          "type": "number",
+          "description": "Minimum value for Range properties. Null for non-range properties."
+        },
+        "RangeMax": {
+          "type": "number",
+          "description": "Maximum value for Range properties. Null for non-range properties."
+        },
+        "DefaultTextureName": {
+          "type": "string",
+          "description": "Default texture name for Texture properties. Null if not applicable."
+        },
+        "Attributes": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "Custom attributes applied to this property. Null if none."
+        }
+      },
+      "required": [
+        "NameId"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData": {
+      "type": "object",
+      "properties": {
+        "Index": {
+          "type": "integer",
+          "description": "Index of this subshader within the shader."
+        },
+        "PassCount": {
+          "type": "integer",
+          "description": "Number of passes in this subshader."
+        },
+        "Passes": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData>",
+          "description": "List of passes in this subshader. Null if no passes."
+        }
+      },
+      "required": [
+        "Index",
+        "PassCount"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+PassData": {
+      "type": "object",
+      "properties": {
+        "Index": {
+          "type": "integer",
+          "description": "Index of this pass within the subshader."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Name of the pass. Null if unnamed."
+        },
+        "SourceCode": {
+          "type": "string",
+          "description": "Source code of the pass. Null if unavailable."
+        }
+      },
+      "required": [
+        "Index"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+          "description": "Reference to the shader asset for future operations."
+        },
+        "Name": {
+          "type": "string",
+          "description": "Full name of the shader (e.g. 'Standard', 'Universal Render Pipeline/Lit')."
+        },
+        "IsSupported": {
+          "type": "boolean",
+          "description": "Whether the shader is supported on the current GPU and platform."
+        },
+        "RenderQueue": {
+          "type": "integer",
+          "description": "The render queue value of the shader."
+        },
+        "HasErrors": {
+          "type": "boolean",
+          "description": "Whether the shader has any compilation errors."
+        },
+        "PropertyCount": {
+          "type": "integer",
+          "description": "Number of properties exposed by the shader."
+        },
+        "PassCount": {
+          "type": "integer",
+          "description": "Total number of passes in the shader."
+        },
+        "RenderType": {
+          "type": "string",
+          "description": "The RenderType tag value from the first pass, if set."
+        },
+        "Messages": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderMessageData>",
+          "description": "Compilation messages including errors and warnings. Null if no messages."
+        },
+        "Properties": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+ShaderPropertyData>",
+          "description": "List of shader properties (uniforms). Null if the shader has no properties."
+        },
+        "Subshaders": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Assets_Shader+SubshaderData>",
+          "description": "List of subshaders with their passes. Null if shader data is unavailable."
+        }
+      },
+      "required": [
+        "IsSupported",
+        "RenderQueue",
+        "HasErrors",
+        "PropertyCount",
+        "PassCount"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/assets-shader-list-all/SKILL.md
+++ b/.gemini/skills/assets-shader-list-all/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: assets-shader-list-all
+description: List all available shaders in the project assets and packages. Returns their names. Use this to find a shader name for 'assets-material-create' tool.
+---
+
+# Assets / List Shaders
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool assets-shader-list-all --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool assets-shader-list-all --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool assets-shader-list-all --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/console-clear-logs/SKILL.md
+++ b/.gemini/skills/console-clear-logs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: console-clear-logs
+description: Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. Useful for isolating errors related to a specific action by clearing logs before performing the action.
+---
+
+# Console / Clear Logs
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool console-clear-logs --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool console-clear-logs --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool console-clear-logs --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/console-get-logs/SKILL.md
+++ b/.gemini/skills/console-get-logs/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: console-get-logs
+description: Retrieves Unity Editor logs. Useful for debugging and monitoring Unity Editor activity.
+---
+
+# Console / Get Logs
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool console-get-logs --input '{
+  "maxEntries": 0,
+  "logTypeFilter": "string_value",
+  "includeStackTrace": false,
+  "lastMinutes": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool console-get-logs --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool console-get-logs --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `maxEntries` | `integer` | No | Maximum number of log entries to return. Minimum: 1. Default: 100 |
+| `logTypeFilter` | `any` | No | Filter by log type. 'null' means All. |
+| `includeStackTrace` | `boolean` | No | Include stack traces in the output. Default: false |
+| `lastMinutes` | `integer` | No | Return logs from the last N minutes. If 0, returns all available logs. Default: 0 |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "maxEntries": {
+      "type": "integer"
+    },
+    "logTypeFilter": {
+      "$ref": "#/$defs/UnityEngine.LogType"
+    },
+    "includeStackTrace": {
+      "type": "boolean"
+    },
+    "lastMinutes": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "UnityEngine.LogType": {
+      "type": "string",
+      "enum": [
+        "Error",
+        "Assert",
+        "Warning",
+        "Log",
+        "Exception"
+      ]
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.LogEntry[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.LogEntry": {
+      "type": "object",
+      "properties": {
+        "LogType": {
+          "type": "string",
+          "enum": [
+            "Error",
+            "Assert",
+            "Warning",
+            "Log",
+            "Exception"
+          ]
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "StackTrace": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "LogType",
+        "Timestamp"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.LogEntry[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.LogEntry"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/editor-application-get-state/SKILL.md
+++ b/.gemini/skills/editor-application-get-state/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: editor-application-get-state
+description: "Returns available information about 'UnityEditor.EditorApplication'. Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc."
+---
+
+# Editor / Application / Get State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-application-get-state --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-application-get-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-application-get-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData",
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData": {
+      "type": "object",
+      "properties": {
+        "IsPlaying": {
+          "type": "boolean",
+          "description": "Whether the Editor is in Play mode."
+        },
+        "IsPaused": {
+          "type": "boolean",
+          "description": "Whether the Editor is paused."
+        },
+        "IsCompiling": {
+          "type": "boolean",
+          "description": "Is editor currently compiling scripts? (Read Only)"
+        },
+        "IsPlayingOrWillChangePlaymode": {
+          "type": "boolean",
+          "description": "Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)"
+        },
+        "IsUpdating": {
+          "type": "boolean",
+          "description": "True if the Editor is currently refreshing the AssetDatabase. (Read Only)"
+        },
+        "ApplicationContentsPath": {
+          "type": "string",
+          "description": "Path to the Unity editor contents folder. (Read Only)"
+        },
+        "ApplicationPath": {
+          "type": "string",
+          "description": "Gets the path to the Unity Editor application. (Read Only)"
+        },
+        "TimeSinceStartup": {
+          "type": "number",
+          "description": "The time since the editor was started. (Read Only)"
+        }
+      },
+      "required": [
+        "IsPlaying",
+        "IsPaused",
+        "IsCompiling",
+        "IsPlayingOrWillChangePlaymode",
+        "IsUpdating",
+        "TimeSinceStartup"
+      ],
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/editor-application-set-state/SKILL.md
+++ b/.gemini/skills/editor-application-set-state/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: editor-application-set-state
+description: Control the Unity Editor application state. You can start, stop, or pause the 'playmode'. Use 'editor-application-get-state' tool to get the current state first.
+---
+
+# Editor / Application / Set State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-application-set-state --input '{
+  "isPlaying": false,
+  "isPaused": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-application-set-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-application-set-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `isPlaying` | `boolean` | No | If true, the 'playmode' will be started. If false, the 'playmode' will be stopped. |
+| `isPaused` | `boolean` | No | If true, the 'playmode' will be paused. If false, the 'playmode' will be resumed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "isPlaying": {
+      "type": "boolean"
+    },
+    "isPaused": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData",
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor+EditorStatsData": {
+      "type": "object",
+      "properties": {
+        "IsPlaying": {
+          "type": "boolean",
+          "description": "Whether the Editor is in Play mode."
+        },
+        "IsPaused": {
+          "type": "boolean",
+          "description": "Whether the Editor is paused."
+        },
+        "IsCompiling": {
+          "type": "boolean",
+          "description": "Is editor currently compiling scripts? (Read Only)"
+        },
+        "IsPlayingOrWillChangePlaymode": {
+          "type": "boolean",
+          "description": "Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)"
+        },
+        "IsUpdating": {
+          "type": "boolean",
+          "description": "True if the Editor is currently refreshing the AssetDatabase. (Read Only)"
+        },
+        "ApplicationContentsPath": {
+          "type": "string",
+          "description": "Path to the Unity editor contents folder. (Read Only)"
+        },
+        "ApplicationPath": {
+          "type": "string",
+          "description": "Gets the path to the Unity Editor application. (Read Only)"
+        },
+        "TimeSinceStartup": {
+          "type": "number",
+          "description": "The time since the editor was started. (Read Only)"
+        }
+      },
+      "required": [
+        "IsPlaying",
+        "IsPaused",
+        "IsCompiling",
+        "IsPlayingOrWillChangePlaymode",
+        "IsUpdating",
+        "TimeSinceStartup"
+      ],
+      "description": "Available information about 'UnityEditor.EditorApplication'."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/editor-selection-get/SKILL.md
+++ b/.gemini/skills/editor-selection-get/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: editor-selection-get
+description: Get information about the current Selection in the Unity Editor. Use 'editor-selection-set' tool to set the selection.
+---
+
+# Editor / Selection / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-selection-get --input '{
+  "includeGameObjects": false,
+  "includeTransforms": false,
+  "includeInstanceIDs": false,
+  "includeAssetGUIDs": false,
+  "includeActiveObject": false,
+  "includeActiveTransform": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-selection-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-selection-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `includeGameObjects` | `boolean` | No |  |
+| `includeTransforms` | `boolean` | No |  |
+| `includeInstanceIDs` | `boolean` | No |  |
+| `includeAssetGUIDs` | `boolean` | No |  |
+| `includeActiveObject` | `boolean` | No |  |
+| `includeActiveTransform` | `boolean` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "includeGameObjects": {
+      "type": "boolean"
+    },
+    "includeTransforms": {
+      "type": "boolean"
+    },
+    "includeInstanceIDs": {
+      "type": "boolean"
+    },
+    "includeAssetGUIDs": {
+      "type": "boolean"
+    },
+    "includeActiveObject": {
+      "type": "boolean"
+    },
+    "includeActiveTransform": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.Int32[]": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData": {
+      "type": "object",
+      "properties": {
+        "GameObjects": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]",
+          "description": "Returns the actual game object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "Transforms": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]",
+          "description": "Returns the top level selection, excluding Prefabs."
+        },
+        "InstanceIDs": {
+          "$ref": "#/$defs/System.Int32[]",
+          "description": "The actual unfiltered selection from the Scene returned as instance ids instead of objects."
+        },
+        "AssetGUIDs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Returns the guids of the selected assets."
+        },
+        "ActiveGameObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Returns the active game object. (The one shown in the inspector)."
+        },
+        "ActiveInstanceID": {
+          "type": "integer",
+          "description": "Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects"
+        },
+        "ActiveObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Returns the actual object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "ActiveTransform": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Returns the active transform. (The one shown in the inspector)."
+        }
+      },
+      "required": [
+        "ActiveInstanceID"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/editor-selection-set/SKILL.md
+++ b/.gemini/skills/editor-selection-set/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: editor-selection-set
+description: Set the current Selection in the Unity Editor to the provided objects. Use 'editor-selection-get' tool to get the current selection first.
+---
+
+# Editor / Selection / Set
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool editor-selection-set --input '{
+  "select": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool editor-selection-set --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool editor-selection-set --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `select` | `any` | Yes |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "select": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+        "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+      }
+    }
+  },
+  "required": [
+    "select"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.Int32[]": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Editor_Selection+SelectionData": {
+      "type": "object",
+      "properties": {
+        "GameObjects": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef[]",
+          "description": "Returns the actual game object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "Transforms": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef[]",
+          "description": "Returns the top level selection, excluding Prefabs."
+        },
+        "InstanceIDs": {
+          "$ref": "#/$defs/System.Int32[]",
+          "description": "The actual unfiltered selection from the Scene returned as instance ids instead of objects."
+        },
+        "AssetGUIDs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Returns the guids of the selected assets."
+        },
+        "ActiveGameObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Returns the active game object. (The one shown in the inspector)."
+        },
+        "ActiveInstanceID": {
+          "type": "integer",
+          "description": "Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects"
+        },
+        "ActiveObject": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Returns the actual object selection. Includes Prefabs, non-modifiable objects."
+        },
+        "ActiveTransform": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Returns the active transform. (The one shown in the inspector)."
+        }
+      },
+      "required": [
+        "ActiveInstanceID"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-component-add/SKILL.md
+++ b/.gemini/skills/gameobject-component-add/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: gameobject-component-add
+description: Add Component to GameObject in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first. Use 'gameobject-component-list-all' tool to find the component type names to add.
+---
+
+# GameObject / Component / Add
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-add --input '{
+  "componentNames": "string_value",
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-add --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-add --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `componentNames` | `any` | Yes | Full name of the Component. It should include full namespace path and the class name. |
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "componentNames": {
+      "$ref": "#/$defs/System.String[]"
+    },
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "componentNames",
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+AddComponentResponse"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+AddComponentResponse": {
+      "type": "object",
+      "properties": {
+        "AddedComponents": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow>",
+          "description": "List of successfully added components."
+        },
+        "Messages": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of success messages for added components."
+        },
+        "Warnings": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of warnings encountered during component addition."
+        },
+        "Errors": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "List of errors encountered during component addition."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-component-destroy/SKILL.md
+++ b/.gemini/skills/gameobject-component-destroy/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: gameobject-component-destroy
+description: Destroy one or many components from target GameObject. Can't destroy missed components. Use 'gameobject-find' tool to find the target GameObject and 'gameobject-component-get' to get component details first.
+---
+
+# GameObject / Component / Destroy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-destroy --input '{
+  "gameObjectRef": "string_value",
+  "destroyComponentRefs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-destroy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-destroy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `destroyComponentRefs` | `any` | Yes | Component reference array. Used to find Component at GameObject. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "destroyComponentRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      },
+      "description": "Component reference array. Used to find Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "destroyComponentRefs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyComponentsResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+        "description": "Component reference. Used to find a Component at GameObject."
+      },
+      "description": "Component reference array. Used to find Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyComponentsResponse": {
+      "type": "object",
+      "properties": {
+        "DestroyedComponents": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRefList",
+          "description": "List of destroyed components."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-component-get/SKILL.md
+++ b/.gemini/skills/gameobject-component-get/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: gameobject-component-get
+description: Get detailed information about a specific Component on a GameObject. Returns component type, enabled state, and optionally serialized fields and properties. Use this to inspect component data before modifying it. Use 'gameobject-find' tool to get the list of all components on the GameObject.
+---
+
+# GameObject / Component / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-get --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "includeFields": false,
+  "includeProperties": false,
+  "deepSerialization": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `componentRef` | `any` | Yes | Component reference. Used to find a Component at GameObject. |
+| `includeFields` | `boolean` | No | Include serialized fields of the component. |
+| `includeProperties` | `boolean` | No | Include serialized properties of the component. |
+| `deepSerialization` | `boolean` | No | Performs deep serialization including all nested objects. Otherwise, only serializes top-level members. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "includeFields": {
+      "type": "boolean"
+    },
+    "includeProperties": {
+      "type": "boolean"
+    },
+    "deepSerialization": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "componentRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+GetComponentResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+GetComponentResponse": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the component for future operations."
+        },
+        "Index": {
+          "type": "integer",
+          "description": "Index of the component in the GameObject's component list."
+        },
+        "Component": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow",
+          "description": "Basic component information (type, enabled state)."
+        },
+        "Fields": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>",
+          "description": "Serialized fields of the component."
+        },
+        "Properties": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.SerializedMember>",
+          "description": "Serialized properties of the component."
+        }
+      },
+      "required": [
+        "Index"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-component-list-all/SKILL.md
+++ b/.gemini/skills/gameobject-component-list-all/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: gameobject-component-list-all
+description: List C# class names extended from UnityEngine.Component. Use this to find component type names for 'gameobject-component-add' tool. Results are paginated to avoid overwhelming responses.
+---
+
+# GameObject / Component / List All
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-list-all --input '{
+  "search": "string_value",
+  "page": 0,
+  "pageSize": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-list-all --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-list-all --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `search` | `string` | No | Substring for searching components. Could be empty. |
+| `page` | `integer` | No | Page number (0-based). Default is 0. |
+| `pageSize` | `integer` | No | Number of items per page. Default is 5. Max is 500. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "search": {
+      "type": "string"
+    },
+    "page": {
+      "type": "integer"
+    },
+    "pageSize": {
+      "type": "integer"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ComponentListResult"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ComponentListResult": {
+      "type": "object",
+      "properties": {
+        "Items": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Array of component type names for the current page."
+        },
+        "Page": {
+          "type": "integer",
+          "description": "Current page number (0-based)."
+        },
+        "PageSize": {
+          "type": "integer",
+          "description": "Number of items per page."
+        },
+        "TotalCount": {
+          "type": "integer",
+          "description": "Total number of matching components."
+        },
+        "TotalPages": {
+          "type": "integer",
+          "description": "Total number of pages available."
+        }
+      },
+      "required": [
+        "Page",
+        "PageSize",
+        "TotalCount",
+        "TotalPages"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-component-modify/SKILL.md
+++ b/.gemini/skills/gameobject-component-modify/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: gameobject-component-modify
+description: Modify a specific Component on a GameObject in opened Prefab or in a Scene. Allows direct modification of component fields and properties without wrapping in GameObject structure. Use 'gameobject-component-get' first to inspect the component structure before modifying.
+---
+
+# GameObject / Component / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-component-modify --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "componentDiff": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-component-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `componentRef` | `any` | Yes | Component reference. Used to find a Component at GameObject. |
+| `componentDiff` | `any` | Yes | The component data to apply. Should contain 'fields' and/or 'props' with the values to modify.
+Only include the fields/properties you want to change.
+Any unknown or invalid fields and properties will be reported in the response. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "componentDiff": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRef",
+    "componentRef",
+    "componentDiff"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ModifyComponentResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+ModifyComponentResponse": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the modified component."
+        },
+        "Index": {
+          "type": "integer",
+          "description": "Index of the component in the GameObject's component list."
+        },
+        "Component": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow",
+          "description": "Updated component information after modification."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "Success",
+        "Index"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-create/SKILL.md
+++ b/.gemini/skills/gameobject-create/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: gameobject-create
+description: Create a new GameObject in opened Prefab or in a Scene. If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.
+---
+
+# GameObject / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-create --input '{
+  "name": "string_value",
+  "parentGameObjectRef": "string_value",
+  "position": "string_value",
+  "rotation": "string_value",
+  "scale": "string_value",
+  "isLocalSpace": false,
+  "primitiveType": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | Name of the new GameObject. |
+| `parentGameObjectRef` | `any` | No | Parent GameObject reference. If not provided, the GameObject will be created at the root of the scene or prefab. |
+| `position` | `any` | No | Transform position of the GameObject. |
+| `rotation` | `any` | No | Transform rotation of the GameObject. Euler angles in degrees. |
+| `scale` | `any` | No | Transform scale of the GameObject. |
+| `isLocalSpace` | `boolean` | No | World or Local space of transform. |
+| `primitiveType` | `any` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "parentGameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "position": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "rotation": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "scale": {
+      "$ref": "#/$defs/UnityEngine.Vector3"
+    },
+    "isLocalSpace": {
+      "type": "boolean"
+    },
+    "primitiveType": {
+      "$ref": "#/$defs/UnityEngine.PrimitiveType"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "UnityEngine.Vector3": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "additionalProperties": false
+    },
+    "UnityEngine.PrimitiveType": {
+      "type": "string",
+      "enum": [
+        "Sphere",
+        "Capsule",
+        "Cylinder",
+        "Cube",
+        "Plane",
+        "Quad"
+      ]
+    }
+  },
+  "required": [
+    "name"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-destroy/SKILL.md
+++ b/.gemini/skills/gameobject-destroy/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gameobject-destroy
+description: Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first.
+---
+
+# GameObject / Destroy
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-destroy --input '{
+  "gameObjectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-destroy --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-destroy --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyGameObjectResult"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_GameObject+DestroyGameObjectResult": {
+      "type": "object",
+      "properties": {
+        "DestroyedName": {
+          "type": "string",
+          "description": "Name of the destroyed GameObject."
+        },
+        "DestroyedPath": {
+          "type": "string",
+          "description": "Hierarchy path of the destroyed GameObject."
+        },
+        "DestroyedInstanceId": {
+          "type": "integer",
+          "description": "Instance ID of the destroyed GameObject."
+        }
+      },
+      "required": [
+        "DestroyedInstanceId"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-duplicate/SKILL.md
+++ b/.gemini/skills/gameobject-duplicate/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: gameobject-duplicate
+description: Duplicate GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+---
+
+# GameObject / Duplicate
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-duplicate --input '{
+  "gameObjectRefs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-duplicate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-duplicate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | Array of GameObjects in opened Prefab or in the active Scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRefs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-find/SKILL.md
+++ b/.gemini/skills/gameobject-find/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: gameobject-find
+description: Finds specific GameObject by provided information in opened Prefab or in a Scene. First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. If no opened Prefab it looks into current active scene. Returns GameObject information and its children. Also, it returns Components preview just for the target GameObject.
+---
+
+# GameObject / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-find --input '{
+  "gameObjectRef": "string_value",
+  "includeData": false,
+  "includeComponents": false,
+  "includeBounds": false,
+  "includeHierarchy": false,
+  "hierarchyDepth": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
+| `includeData` | `boolean` | No | Include editable GameObject data (tag, layer, etc). |
+| `includeComponents` | `boolean` | No | Include attached components references. |
+| `includeBounds` | `boolean` | No | Include 3D bounds of the GameObject. |
+| `includeHierarchy` | `boolean` | No | Include hierarchy metadata. |
+| `hierarchyDepth` | `integer` | No | Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "includeData": {
+      "type": "boolean"
+    },
+    "includeComponents": {
+      "type": "boolean"
+    },
+    "includeBounds": {
+      "type": "boolean"
+    },
+    "includeHierarchy": {
+      "type": "boolean"
+    },
+    "hierarchyDepth": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "UnityEngine.Bounds": {
+      "type": "object",
+      "properties": {
+        "center": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "size": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "required": [
+        "center",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sceneName": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "activeSelf": {
+          "type": "boolean"
+        },
+        "activeInHierarchy": {
+          "type": "boolean"
+        },
+        "children": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>"
+        }
+      },
+      "required": [
+        "instanceID",
+        "activeSelf",
+        "activeInHierarchy"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Find GameObject in opened Prefab or in the active Scene."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "GameObject editable data (tag, layer, etc)."
+        },
+        "Bounds": {
+          "$ref": "#/$defs/UnityEngine.Bounds",
+          "description": "Bounds of the GameObject."
+        },
+        "Hierarchy": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata",
+          "description": "Hierarchy metadata of the GameObject."
+        },
+        "Components": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]",
+          "description": "Attached components shallow data of the GameObject (Read-only, use Component modification tool for modification)."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-modify/SKILL.md
+++ b/.gemini/skills/gameobject-modify/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: gameobject-modify
+description: Modify GameObject fields and properties in opened Prefab or in a Scene. You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.
+---
+
+# GameObject / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-modify --input '{
+  "gameObjectRefs": "string_value",
+  "gameObjectDiffs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | Array of GameObjects in opened Prefab or in the active Scene. |
+| `gameObjectDiffs` | `any` | Yes | Each item in the array represents a GameObject modification of the 'gameObjectRefs' at the same index. Usually a GameObject is a container for components. Each component may have fields and properties for modification. If you need to modify components of a GameObject, please use 'gameobject-component-modify' tool. Ignore values that should not be modified. Any unknown or wrong located fields and properties will be ignored. Check the result of this command to see what was changed. The ignored fields and properties will be listed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    },
+    "gameObjectDiffs": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRefs",
+    "gameObjectDiffs"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.Logs"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.LogEntry": {
+      "type": "object",
+      "properties": {
+        "Depth": {
+          "type": "integer"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Success",
+            "Warning",
+            "Error",
+            "Critical"
+          ]
+        }
+      },
+      "required": [
+        "Depth",
+        "Type"
+      ]
+    },
+    "com.IvanMurzak.ReflectorNet.Model.Logs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.LogEntry"
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/gameobject-set-parent/SKILL.md
+++ b/.gemini/skills/gameobject-set-parent/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: gameobject-set-parent
+description: Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+---
+
+# GameObject / Set Parent
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool gameobject-set-parent --input '{
+  "gameObjectRefs": "string_value",
+  "parentGameObjectRef": "string_value",
+  "worldPositionStays": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool gameobject-set-parent --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool gameobject-set-parent --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRefs` | `any` | Yes | List of references to the GameObjects to set new parent. |
+| `parentGameObjectRef` | `any` | Yes | Reference to the parent GameObject. |
+| `worldPositionStays` | `boolean` | No | A boolean flag indicating whether the GameObject's world position should remain unchanged when setting its parent. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRefs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList"
+    },
+    "parentGameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "worldPositionStays": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRefList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+        "description": "Find GameObject in opened Prefab or in the active Scene."
+      },
+      "description": "Array of GameObjects in opened Prefab or in the active Scene."
+    }
+  },
+  "required": [
+    "gameObjectRefs",
+    "parentGameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/object-get-data/SKILL.md
+++ b/.gemini/skills/object-get-data/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: object-get-data
+description: Get data of the specified Unity Object. Returns serialized data of the object including its properties and fields. If need to modify the data use 'object-modify' tool.
+---
+
+# Object / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool object-get-data --input '{
+  "objectRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool object-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool object-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectRef` | `any` | Yes | Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "objectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    }
+  },
+  "required": [
+    "objectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/object-modify/SKILL.md
+++ b/.gemini/skills/object-modify/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: object-modify
+description: Modify the specified Unity Object. Allows direct modification of object fields and properties. Use 'object-get-data' first to inspect the object structure before modifying.
+---
+
+# Object / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool object-modify --input '{
+  "objectRef": "string_value",
+  "objectDiff": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool object-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool object-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `objectRef` | `any` | Yes | Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object. |
+| `objectDiff` | `any` | Yes | The object data to apply. Should contain 'fields' and/or 'props' with the values to modify.
+Only include the fields/properties you want to change.
+Any unknown or invalid fields and properties will be reported in the response. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "objectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef"
+    },
+    "objectDiff": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "objectRef",
+    "objectDiff"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Object+ModifyObjectResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object instance. It could be GameObject, Component, Asset, etc. Anything extended from UnityEngine.Object."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Object+ModifyObjectResponse": {
+      "type": "object",
+      "properties": {
+        "Success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ObjectRef",
+          "description": "Reference to the modified object."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Updated object data after modification."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "Success"
+      ]
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/package-add/SKILL.md
+++ b/.gemini/skills/package-add/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: package-add
+description: "Install a package from the Unity Package Manager registry, Git URL, or local path. This operation modifies the project's manifest.json and triggers package resolution. Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. Use 'package-search' tool to search for packages and 'package-list' to list installed packages."
+---
+
+# Package Manager / Add
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-add --input '{
+  "packageId": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-add --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-add --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `packageId` | `string` | Yes | The package ID to install. Formats: Package ID 'com.unity.textmeshpro' (installs latest compatible version), Package ID with version 'com.unity.textmeshpro@3.0.6', Git URL 'https://github.com/user/repo.git', Git URL with branch/tag 'https://github.com/user/repo.git#v1.0.0', Local path 'file:../MyPackage'. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "packageId"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/package-list/SKILL.md
+++ b/.gemini/skills/package-list/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: package-list
+description: List all packages installed in the Unity project (UPM packages). Returns information about each installed package including name, version, source, and description. Use this to check which packages are currently installed before adding or removing packages.
+---
+
+# Package Manager / List Installed
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-list --input '{
+  "sourceFilter": "string_value",
+  "nameFilter": "string_value",
+  "directDependenciesOnly": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-list --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-list --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sourceFilter` | `string` | No | Filter packages by source. |
+| `nameFilter` | `string` | No | Filter packages by name, display name, or description (case-insensitive). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. |
+| `directDependenciesOnly` | `boolean` | No | Include only direct dependencies (packages in manifest.json). If false, includes all resolved packages. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sourceFilter": {
+      "type": "string",
+      "enum": [
+        "All",
+        "Registry",
+        "Embedded",
+        "Local",
+        "Git",
+        "BuiltIn",
+        "LocalTarball"
+      ]
+    },
+    "nameFilter": {
+      "type": "string"
+    },
+    "directDependenciesOnly": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The official Unity name of the package used as the package ID."
+        },
+        "DisplayName": {
+          "type": "string",
+          "description": "The display name of the package."
+        },
+        "Version": {
+          "type": "string",
+          "description": "The version of the package."
+        },
+        "Description": {
+          "type": "string",
+          "description": "A brief description of the package."
+        },
+        "Source": {
+          "type": "string",
+          "description": "The source of the package (Registry, Embedded, Local, Git, etc.)."
+        },
+        "Category": {
+          "type": "string",
+          "description": "The category of the package."
+        }
+      },
+      "description": "Package information returned from package list operation."
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageData",
+        "description": "Package information returned from package list operation."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/package-remove/SKILL.md
+++ b/.gemini/skills/package-remove/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: package-remove
+description: "Remove (uninstall) a package from the Unity project. This removes the package from the project's manifest.json and triggers package resolution. Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. Use 'package-list' tool to list installed packages first."
+---
+
+# Package Manager / Remove
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-remove --input '{
+  "packageId": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-remove --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-remove --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `packageId` | `string` | Yes | The ID of the package to remove. Example: 'com.unity.textmeshpro'. Do not include version number. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "packageId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "packageId"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/package-search/SKILL.md
+++ b/.gemini/skills/package-search/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: package-search
+description: "Search for packages in both Unity Package Manager registry and installed packages. Use this to find packages by name before installing them. Returns available versions and installation status. Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. Note: Online mode fetches exact matches from live registry, then supplements with cached substring matches."
+---
+
+# Package Manager / Search
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool package-search --input '{
+  "query": "string_value",
+  "maxResults": 0,
+  "offlineMode": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool package-search --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool package-search --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | Yes | The package id, name, or description. Can be: Full package id 'com.unity.textmeshpro', Full package name 'TextMesh Pro', Partial name 'TextMesh' (will search in Unity registry and installed packages), Description keyword 'rendering' (searches in package descriptions). |
+| `maxResults` | `integer` | No | Maximum number of results to return. Default: 10 |
+| `offlineMode` | `boolean` | No | Whether to perform the search in offline mode (uses cached registry data only). Default: true. Set to false to fetch latest exact matches from Unity registry. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": {
+      "type": "string"
+    },
+    "maxResults": {
+      "type": "integer"
+    },
+    "offlineMode": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "query"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult>"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "The official Unity name of the package used as the package ID."
+        },
+        "DisplayName": {
+          "type": "string",
+          "description": "The display name of the package."
+        },
+        "LatestVersion": {
+          "type": "string",
+          "description": "The latest version available in the registry."
+        },
+        "Description": {
+          "type": "string",
+          "description": "A brief description of the package."
+        },
+        "IsInstalled": {
+          "type": "boolean",
+          "description": "Whether this package is already installed in the project."
+        },
+        "InstalledVersion": {
+          "type": "string",
+          "description": "The currently installed version (if installed)."
+        },
+        "AvailableVersions": {
+          "$ref": "#/$defs/System.Collections.Generic.List<System.String>",
+          "description": "Available versions of this package (up to 5 most recent)."
+        }
+      },
+      "required": [
+        "IsInstalled"
+      ],
+      "description": "Package search result with available versions."
+    },
+    "System.Collections.Generic.List<System.String>": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Package+PackageSearchResult",
+        "description": "Package search result with available versions."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/particle-system-get/SKILL.md
+++ b/.gemini/skills/particle-system-get/SKILL.md
@@ -1,0 +1,518 @@
+---
+name: particle-system-get
+description: Get detailed information about a ParticleSystem component on a GameObject. Returns particle system state and optionally serialized data for each module. Use the boolean flags to request specific modules. Use this to inspect ParticleSystem data before modifying it.
+---
+
+# ParticleSystem / Get
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool particle-system-get --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "includeMain": false,
+  "includeEmission": false,
+  "includeShape": false,
+  "includeVelocityOverLifetime": false,
+  "includeLimitVelocityOverLifetime": false,
+  "includeInheritVelocity": false,
+  "includeLifetimeByEmitterSpeed": false,
+  "includeForceOverLifetime": false,
+  "includeColorOverLifetime": false,
+  "includeColorBySpeed": false,
+  "includeSizeOverLifetime": false,
+  "includeSizeBySpeed": false,
+  "includeRotationOverLifetime": false,
+  "includeRotationBySpeed": false,
+  "includeExternalForces": false,
+  "includeNoise": false,
+  "includeCollision": false,
+  "includeTrigger": false,
+  "includeSubEmitters": false,
+  "includeTextureSheetAnimation": false,
+  "includeLights": false,
+  "includeTrails": false,
+  "includeCustomData": false,
+  "includeRenderer": false,
+  "includeAll": false,
+  "deepSerialization": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool particle-system-get --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool particle-system-get --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Reference to the GameObject containing the ParticleSystem component. |
+| `componentRef` | `any` | No | Optional reference to a specific ParticleSystem component if the GameObject has multiple. If not provided, uses the first ParticleSystem found. |
+| `includeMain` | `boolean` | No | Include Main module data (duration, looping, prewarm, startDelay, startLifetime, startSpeed, startSize, startRotation, startColor, gravityModifier, simulationSpace, scalingMode, playOnAwake, maxParticles, etc.). |
+| `includeEmission` | `boolean` | No | Include Emission module data (rateOverTime, rateOverDistance, bursts). |
+| `includeShape` | `boolean` | No | Include Shape module data (shapeType, radius, angle, arc, position, rotation, scale, mesh, texture, etc.). |
+| `includeVelocityOverLifetime` | `boolean` | No | Include Velocity over Lifetime module data (x, y, z, space, orbital, radial, speedModifier). |
+| `includeLimitVelocityOverLifetime` | `boolean` | No | Include Limit Velocity over Lifetime module data (limit, dampen, separateAxes, drag). |
+| `includeInheritVelocity` | `boolean` | No | Include Inherit Velocity module data (mode, curve). |
+| `includeLifetimeByEmitterSpeed` | `boolean` | No | Include Lifetime by Emitter Speed module data (curve, range). |
+| `includeForceOverLifetime` | `boolean` | No | Include Force over Lifetime module data (x, y, z, space, randomized). |
+| `includeColorOverLifetime` | `boolean` | No | Include Color over Lifetime module data (color gradient). |
+| `includeColorBySpeed` | `boolean` | No | Include Color by Speed module data (color, range). |
+| `includeSizeOverLifetime` | `boolean` | No | Include Size over Lifetime module data (size curve, separateAxes). |
+| `includeSizeBySpeed` | `boolean` | No | Include Size by Speed module data (size, range). |
+| `includeRotationOverLifetime` | `boolean` | No | Include Rotation over Lifetime module data (angular velocity, separateAxes). |
+| `includeRotationBySpeed` | `boolean` | No | Include Rotation by Speed module data (angular velocity, range). |
+| `includeExternalForces` | `boolean` | No | Include External Forces module data (multiplier, influenceFilter). |
+| `includeNoise` | `boolean` | No | Include Noise module data (strength, frequency, scrollSpeed, damping, octaves, quality, remap). |
+| `includeCollision` | `boolean` | No | Include Collision module data (type, mode, planes, dampen, bounce, lifetimeLoss). |
+| `includeTrigger` | `boolean` | No | Include Trigger module data (inside, outside, enter, exit actions). |
+| `includeSubEmitters` | `boolean` | No | Include Sub Emitters module data (birth, collision, death, trigger, manual emitters). |
+| `includeTextureSheetAnimation` | `boolean` | No | Include Texture Sheet Animation module data (mode, tiles, animation, frameOverTime). |
+| `includeLights` | `boolean` | No | Include Lights module data (ratio, light, color, range, intensity). |
+| `includeTrails` | `boolean` | No | Include Trails module data (mode, ratio, lifetime, width, color). |
+| `includeCustomData` | `boolean` | No | Include Custom Data module data (modes, vectors, colors). |
+| `includeRenderer` | `boolean` | No | Include Renderer module data (renderMode, material, sortMode, alignment, shadows). |
+| `includeAll` | `boolean` | No | Include ALL modules data. Overrides individual flags. |
+| `deepSerialization` | `boolean` | No | Performs deep serialization including all nested objects. Otherwise, only serializes top-level members. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "includeMain": {
+      "type": "boolean"
+    },
+    "includeEmission": {
+      "type": "boolean"
+    },
+    "includeShape": {
+      "type": "boolean"
+    },
+    "includeVelocityOverLifetime": {
+      "type": "boolean"
+    },
+    "includeLimitVelocityOverLifetime": {
+      "type": "boolean"
+    },
+    "includeInheritVelocity": {
+      "type": "boolean"
+    },
+    "includeLifetimeByEmitterSpeed": {
+      "type": "boolean"
+    },
+    "includeForceOverLifetime": {
+      "type": "boolean"
+    },
+    "includeColorOverLifetime": {
+      "type": "boolean"
+    },
+    "includeColorBySpeed": {
+      "type": "boolean"
+    },
+    "includeSizeOverLifetime": {
+      "type": "boolean"
+    },
+    "includeSizeBySpeed": {
+      "type": "boolean"
+    },
+    "includeRotationOverLifetime": {
+      "type": "boolean"
+    },
+    "includeRotationBySpeed": {
+      "type": "boolean"
+    },
+    "includeExternalForces": {
+      "type": "boolean"
+    },
+    "includeNoise": {
+      "type": "boolean"
+    },
+    "includeCollision": {
+      "type": "boolean"
+    },
+    "includeTrigger": {
+      "type": "boolean"
+    },
+    "includeSubEmitters": {
+      "type": "boolean"
+    },
+    "includeTextureSheetAnimation": {
+      "type": "boolean"
+    },
+    "includeLights": {
+      "type": "boolean"
+    },
+    "includeTrails": {
+      "type": "boolean"
+    },
+    "includeCustomData": {
+      "type": "boolean"
+    },
+    "includeRenderer": {
+      "type": "boolean"
+    },
+    "includeAll": {
+      "type": "boolean"
+    },
+    "deepSerialization": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.GetParticleSystemResponse",
+      "description": "Response containing ParticleSystem data with requested modules."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.GetParticleSystemResponse": {
+      "type": "object",
+      "properties": {
+        "gameObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Reference to the GameObject containing the ParticleSystem component."
+        },
+        "componentRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the ParticleSystem component."
+        },
+        "componentIndex": {
+          "type": "integer",
+          "description": "Index of the ParticleSystem component in the GameObject's component list."
+        },
+        "isPlaying": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently playing."
+        },
+        "isPaused": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently paused."
+        },
+        "isEmitting": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently emitting."
+        },
+        "isStopped": {
+          "type": "boolean",
+          "description": "Whether the ParticleSystem is currently stopped."
+        },
+        "particleCount": {
+          "type": "integer",
+          "description": "Current particle count."
+        },
+        "time": {
+          "type": "number",
+          "description": "Current simulation time."
+        },
+        "main": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Main module data."
+        },
+        "emission": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Emission module data."
+        },
+        "shape": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Shape module data."
+        },
+        "velocityOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Velocity over Lifetime module data."
+        },
+        "limitVelocityOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Limit Velocity over Lifetime module data."
+        },
+        "inheritVelocity": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Inherit Velocity module data."
+        },
+        "lifetimeByEmitterSpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Lifetime by Emitter Speed module data."
+        },
+        "forceOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Force over Lifetime module data."
+        },
+        "colorOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Color over Lifetime module data."
+        },
+        "colorBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Color by Speed module data."
+        },
+        "sizeOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Size over Lifetime module data."
+        },
+        "sizeBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Size by Speed module data."
+        },
+        "rotationOverLifetime": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Rotation over Lifetime module data."
+        },
+        "rotationBySpeed": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Rotation by Speed module data."
+        },
+        "externalForces": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "External Forces module data."
+        },
+        "noise": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Noise module data."
+        },
+        "collision": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Collision module data."
+        },
+        "trigger": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Trigger module data."
+        },
+        "subEmitters": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Sub Emitters module data."
+        },
+        "textureSheetAnimation": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Texture Sheet Animation module data."
+        },
+        "lights": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Lights module data."
+        },
+        "trails": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Trails module data."
+        },
+        "customData": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Custom Data module data."
+        },
+        "renderer": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "Renderer module data."
+        }
+      },
+      "required": [
+        "componentIndex",
+        "isPlaying",
+        "isPaused",
+        "isEmitting",
+        "isStopped",
+        "particleCount",
+        "time"
+      ],
+      "description": "Response containing ParticleSystem data with requested modules."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/particle-system-modify/SKILL.md
+++ b/.gemini/skills/particle-system-modify/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: particle-system-modify
+description: Modify a ParticleSystem component on a GameObject. Provide the data model with only the modules you want to change. Use 'particle-system-get' first to inspect the ParticleSystem structure before modifying. Only include the modules and properties you want to change.
+---
+
+# ParticleSystem / Modify
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool particle-system-modify --input '{
+  "gameObjectRef": "string_value",
+  "componentRef": "string_value",
+  "main": "string_value",
+  "emission": "string_value",
+  "shape": "string_value",
+  "velocityOverLifetime": "string_value",
+  "limitVelocityOverLifetime": "string_value",
+  "inheritVelocity": "string_value",
+  "lifetimeByEmitterSpeed": "string_value",
+  "forceOverLifetime": "string_value",
+  "colorOverLifetime": "string_value",
+  "colorBySpeed": "string_value",
+  "sizeOverLifetime": "string_value",
+  "sizeBySpeed": "string_value",
+  "rotationOverLifetime": "string_value",
+  "rotationBySpeed": "string_value",
+  "externalForces": "string_value",
+  "noise": "string_value",
+  "collision": "string_value",
+  "trigger": "string_value",
+  "subEmitters": "string_value",
+  "textureSheetAnimation": "string_value",
+  "lights": "string_value",
+  "trails": "string_value",
+  "customData": "string_value",
+  "renderer": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool particle-system-modify --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool particle-system-modify --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `gameObjectRef` | `any` | Yes | Reference to the GameObject containing the ParticleSystem component. |
+| `componentRef` | `any` | No | Optional reference to a specific ParticleSystem component if the GameObject has multiple. If not provided, uses the first ParticleSystem found. |
+| `main` | `any` | No | Main module data to apply. Only include properties you want to change. |
+| `emission` | `any` | No | Emission module data to apply. Only include properties you want to change. |
+| `shape` | `any` | No | Shape module data to apply. Only include properties you want to change. |
+| `velocityOverLifetime` | `any` | No | Velocity over Lifetime module data to apply. Only include properties you want to change. |
+| `limitVelocityOverLifetime` | `any` | No | Limit Velocity over Lifetime module data to apply. Only include properties you want to change. |
+| `inheritVelocity` | `any` | No | Inherit Velocity module data to apply. Only include properties you want to change. |
+| `lifetimeByEmitterSpeed` | `any` | No | Lifetime by Emitter Speed module data to apply. Only include properties you want to change. |
+| `forceOverLifetime` | `any` | No | Force over Lifetime module data to apply. Only include properties you want to change. |
+| `colorOverLifetime` | `any` | No | Color over Lifetime module data to apply. Only include properties you want to change. |
+| `colorBySpeed` | `any` | No | Color by Speed module data to apply. Only include properties you want to change. |
+| `sizeOverLifetime` | `any` | No | Size over Lifetime module data to apply. Only include properties you want to change. |
+| `sizeBySpeed` | `any` | No | Size by Speed module data to apply. Only include properties you want to change. |
+| `rotationOverLifetime` | `any` | No | Rotation over Lifetime module data to apply. Only include properties you want to change. |
+| `rotationBySpeed` | `any` | No | Rotation by Speed module data to apply. Only include properties you want to change. |
+| `externalForces` | `any` | No | External Forces module data to apply. Only include properties you want to change. |
+| `noise` | `any` | No | Noise module data to apply. Only include properties you want to change. |
+| `collision` | `any` | No | Collision module data to apply. Only include properties you want to change. |
+| `trigger` | `any` | No | Trigger module data to apply. Only include properties you want to change. |
+| `subEmitters` | `any` | No | Sub Emitters module data to apply. Only include properties you want to change. |
+| `textureSheetAnimation` | `any` | No | Texture Sheet Animation module data to apply. Only include properties you want to change. |
+| `lights` | `any` | No | Lights module data to apply. Only include properties you want to change. |
+| `trails` | `any` | No | Trails module data to apply. Only include properties you want to change. |
+| `customData` | `any` | No | Custom Data module data to apply. Only include properties you want to change. |
+| `renderer` | `any` | No | Renderer module data to apply. Only include properties you want to change. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "gameObjectRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "componentRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef"
+    },
+    "main": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "emission": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "shape": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "velocityOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "limitVelocityOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "inheritVelocity": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "lifetimeByEmitterSpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "forceOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "colorOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "colorBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "sizeOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "sizeBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "rotationOverLifetime": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "rotationBySpeed": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "externalForces": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "noise": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "collision": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "trigger": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "subEmitters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "textureSheetAnimation": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "lights": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "trails": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "customData": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "renderer": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "gameObjectRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.ModifyParticleSystemResponse",
+      "description": "Response containing the result of modifying a ParticleSystem."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "description": "Component 'index' attached to a gameObject. The first index is '0' and that is usually Transform or RectTransform. Priority: 2. Default value is -1."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Component type full name. Sample 'UnityEngine.Transform'. If the gameObject has two components of the same type, the output component is unpredictable. Priority: 3. Default value is null."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "index",
+        "instanceID"
+      ],
+      "description": "Component reference. Used to find a Component at GameObject."
+    },
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.ParticleSystem.Editor.ModifyParticleSystemResponse": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "description": "Whether the modification was successful."
+        },
+        "gameObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Reference to the GameObject containing the ParticleSystem component."
+        },
+        "componentRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentRef",
+          "description": "Reference to the modified ParticleSystem component."
+        },
+        "componentIndex": {
+          "type": "integer",
+          "description": "Index of the ParticleSystem component in the GameObject's component list."
+        },
+        "logs": {
+          "$ref": "#/$defs/System.String[]",
+          "description": "Log of modifications made and any warnings/errors encountered."
+        }
+      },
+      "required": [
+        "success",
+        "componentIndex"
+      ],
+      "description": "Response containing the result of modifying a ParticleSystem."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/ping/SKILL.md
+++ b/.gemini/skills/ping/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ping
+description: Lightweight readiness probe. Returns the input message or 'pong' if omitted.
+---
+
+# Ping
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool ping --input '{
+  "message": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool ping --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool ping --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message` | `string` | No | Optional message to echo back. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/reflection-method-call/SKILL.md
+++ b/.gemini/skills/reflection-method-call/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: reflection-method-call
+description: Call C# method. Any method could be called, even private methods. It requires to receive proper method schema. Use 'reflection-method-find' to find available method before using it. Receives input parameters and returns result.
+---
+
+# Method C# / Call
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool reflection-method-call --input '{
+  "filter": "string_value",
+  "knownNamespace": false,
+  "typeNameMatchLevel": 0,
+  "methodNameMatchLevel": 0,
+  "parametersMatchLevel": 0,
+  "targetObject": "string_value",
+  "inputParameters": "string_value",
+  "executeInMainThread": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool reflection-method-call --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool reflection-method-call --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `any` | Yes | Method reference. Used to find method in codebase of the project. |
+| `knownNamespace` | `boolean` | No | Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false. |
+| `typeNameMatchLevel` | `integer` | No | Minimal match level for 'typeName'. 0 - ignore 'filter.typeName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `methodNameMatchLevel` | `integer` | No | Minimal match level for 'MethodName'. 0 - ignore 'filter.MethodName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `parametersMatchLevel` | `integer` | No | Minimal match level for 'Parameters'. 0 - ignore 'filter.Parameters', 1 - parameters count is the same, 2 - equals (default value). |
+| `targetObject` | `any` | No | Specify target object to call method on. Should be null if the method is static or if there is no specific target instance. New instance of the specified class will be created if the method is instance method and the targetObject is null. Required: type - full type name of the object to call method on, value - serialized object value (it will be deserialized to the specified type). |
+| `inputParameters` | `any` | No | Method input parameters. Per each parameter specify: type - full type name of the object to call method on, name - parameter name, value - serialized object value (it will be deserialized to the specified type). |
+| `executeInMainThread` | `boolean` | No | Set to true if the method should be executed in the main thread. Otherwise, set to false. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef"
+    },
+    "knownNamespace": {
+      "type": "boolean"
+    },
+    "typeNameMatchLevel": {
+      "type": "integer"
+    },
+    "methodNameMatchLevel": {
+      "type": "integer"
+    },
+    "parametersMatchLevel": {
+      "type": "integer"
+    },
+    "targetObject": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    },
+    "inputParameters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    },
+    "executeInMainThread": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter",
+        "description": "Parameter of a method. Contains type and name of the parameter."
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Type of the parameter including namespace. Sample: 'System.String', 'System.Int32', 'UnityEngine.GameObject', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the parameter. It may be empty if the name is unknown."
+        }
+      },
+      "description": "Parameter of a method. Contains type and name of the parameter."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the class. It may be empty if the class is in the global namespace or the namespace is unknown."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Class name, or substring a class name. It may be empty if the class is unknown."
+        },
+        "methodName": {
+          "type": "string",
+          "description": "Method name, or substring of the method name. It may be empty if the method is unknown."
+        },
+        "inputParameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>",
+          "description": "List of input parameters. Can be null if the method has no parameters or the parameters are unknown."
+        }
+      },
+      "description": "Method reference. Used to find method in codebase of the project."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "filter"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/reflection-method-find/SKILL.md
+++ b/.gemini/skills/reflection-method-find/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: reflection-method-find
+description: Find method in the project using C# Reflection. It looks for all assemblies in the project and finds method by its name, class name and parameters. Even private methods are available. Use 'reflection-method-call' to call the method after finding it.
+---
+
+# Method C# / Find
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool reflection-method-find --input '{
+  "filter": "string_value",
+  "knownNamespace": false,
+  "typeNameMatchLevel": 0,
+  "methodNameMatchLevel": 0,
+  "parametersMatchLevel": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool reflection-method-find --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool reflection-method-find --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filter` | `any` | Yes | Method reference. Used to find method in codebase of the project. |
+| `knownNamespace` | `boolean` | No | Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false. |
+| `typeNameMatchLevel` | `integer` | No | Minimal match level for 'typeName'. 0 - ignore 'filter.typeName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `methodNameMatchLevel` | `integer` | No | Minimal match level for 'MethodName'. 0 - ignore 'filter.MethodName', 1 - contains ignoring case (default value), 2 - contains case sensitive, 3 - starts with ignoring case, 4 - starts with case sensitive, 5 - equals ignoring case, 6 - equals case sensitive. |
+| `parametersMatchLevel` | `integer` | No | Minimal match level for 'Parameters'. 0 - ignore 'filter.Parameters' (default value), 1 - parameters count is the same, 2 - equals. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filter": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef"
+    },
+    "knownNamespace": {
+      "type": "boolean"
+    },
+    "typeNameMatchLevel": {
+      "type": "integer"
+    },
+    "methodNameMatchLevel": {
+      "type": "integer"
+    },
+    "parametersMatchLevel": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter",
+        "description": "Parameter of a method. Contains type and name of the parameter."
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Type of the parameter including namespace. Sample: 'System.String', 'System.Int32', 'UnityEngine.GameObject', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the parameter. It may be empty if the name is unknown."
+        }
+      },
+      "description": "Parameter of a method. Contains type and name of the parameter."
+    },
+    "com.IvanMurzak.ReflectorNet.Model.MethodRef": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the class. It may be empty if the class is in the global namespace or the namespace is unknown."
+        },
+        "typeName": {
+          "type": "string",
+          "description": "Class name, or substring a class name. It may be empty if the class is unknown."
+        },
+        "methodName": {
+          "type": "string",
+          "description": "Method name, or substring of the method name. It may be empty if the method is unknown."
+        },
+        "inputParameters": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.ReflectorNet.Model.MethodRef+Parameter>",
+          "description": "List of input parameters. Can be null if the method has no parameters or the parameters are unknown."
+        }
+      },
+      "description": "Method reference. Used to find method in codebase of the project."
+    }
+  },
+  "required": [
+    "filter"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-create/SKILL.md
+++ b/.gemini/skills/scene-create/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: scene-create
+description: Create new scene in the project assets. Use 'scene-list-opened' tool to list all opened scenes after creation.
+---
+
+# Scene / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-create --input '{
+  "path": "string_value",
+  "newSceneSetup": "string_value",
+  "newSceneMode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Yes | Path to the scene file. Should end with ".unity" extension. |
+| `newSceneSetup` | `any` | No |  |
+| `newSceneMode` | `any` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "newSceneSetup": {
+      "$ref": "#/$defs/UnityEditor.SceneManagement.NewSceneSetup"
+    },
+    "newSceneMode": {
+      "$ref": "#/$defs/UnityEditor.SceneManagement.NewSceneMode"
+    }
+  },
+  "$defs": {
+    "UnityEditor.SceneManagement.NewSceneSetup": {
+      "type": "string",
+      "enum": [
+        "EmptyScene",
+        "DefaultGameObjects"
+      ]
+    },
+    "UnityEditor.SceneManagement.NewSceneMode": {
+      "type": "string",
+      "enum": [
+        "Single",
+        "Additive"
+      ]
+    }
+  },
+  "required": [
+    "path"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-get-data/SKILL.md
+++ b/.gemini/skills/scene-get-data/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: scene-get-data
+description: This tool retrieves the list of root GameObjects in the specified scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Get Data
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-get-data --input '{
+  "openedSceneName": "string_value",
+  "includeRootGameObjects": false,
+  "includeChildrenDepth": 0,
+  "includeBounds": false,
+  "includeData": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-get-data --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-get-data --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `openedSceneName` | `string` | No | Name of the opened scene. If empty or null, the active scene will be used. |
+| `includeRootGameObjects` | `boolean` | No | If true, includes root GameObjects in the scene data. |
+| `includeChildrenDepth` | `integer` | No | Determines the depth of the hierarchy to include. |
+| `includeBounds` | `boolean` | No | If true, includes bounding box information for GameObjects. |
+| `includeData` | `boolean` | No | If true, includes component data for GameObjects. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "openedSceneName": {
+      "type": "string"
+    },
+    "includeRootGameObjects": {
+      "type": "boolean"
+    },
+    "includeChildrenDepth": {
+      "type": "integer"
+    },
+    "includeBounds": {
+      "type": "boolean"
+    },
+    "includeData": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneData",
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "$defs": {
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData": {
+      "type": "object",
+      "properties": {
+        "Reference": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef",
+          "description": "Find GameObject in opened Prefab or in the active Scene."
+        },
+        "Data": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+          "description": "GameObject editable data (tag, layer, etc)."
+        },
+        "Bounds": {
+          "$ref": "#/$defs/UnityEngine.Bounds",
+          "description": "Bounds of the GameObject."
+        },
+        "Hierarchy": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata",
+          "description": "Hierarchy metadata of the GameObject."
+        },
+        "Components": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]",
+          "description": "Attached components shallow data of the GameObject (Read-only, use Component modification tool for modification)."
+        }
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "UnityEngine.Bounds": {
+      "type": "object",
+      "properties": {
+        "center": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        },
+        "size": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "number"
+            },
+            "y": {
+              "type": "number"
+            },
+            "z": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "required": [
+        "center",
+        "size"
+      ],
+      "additionalProperties": false
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sceneName": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "activeSelf": {
+          "type": "boolean"
+        },
+        "activeInHierarchy": {
+          "type": "boolean"
+        },
+        "children": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>"
+        }
+      },
+      "required": [
+        "instanceID",
+        "activeSelf",
+        "activeInHierarchy"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectMetadata"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.ComponentDataShallow": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer"
+        },
+        "typeName": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "string",
+          "enum": [
+            "False",
+            "True",
+            "NA"
+          ]
+        }
+      },
+      "required": [
+        "instanceID",
+        "isEnabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneData": {
+      "type": "object",
+      "properties": {
+        "RootGameObjects": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectData>"
+        },
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-list-opened/SKILL.md
+++ b/.gemini/skills/scene-list-opened/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: scene-list-opened
+description: Returns the list of currently opened scenes in Unity Editor. Use 'scene-get-data' tool to get detailed information about a specific scene.
+---
+
+# Scene / List Opened
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-list-opened --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-list-opened --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-list-opened --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-open/SKILL.md
+++ b/.gemini/skills/scene-open/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: scene-open
+description: Open scene from the project asset file. Use 'assets-find' tool to find the scene asset first.
+---
+
+# Scene / Open
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-open --input '{
+  "sceneRef": "string_value",
+  "loadSceneMode": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-open --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-open --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sceneRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+| `loadSceneMode` | `string` | No | Open scene mode. Single: closes the current scenes and opens a new one. Additive: keeps the current scene and opens additional one. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sceneRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    },
+    "loadSceneMode": {
+      "type": "string",
+      "enum": [
+        "Single",
+        "Additive",
+        "AdditiveWithoutLoading"
+      ]
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "sceneRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-save/SKILL.md
+++ b/.gemini/skills/scene-save/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: scene-save
+description: Save Opened scene to the asset file. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Save
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-save --input '{
+  "openedSceneName": "string_value",
+  "path": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-save --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-save --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `openedSceneName` | `string` | No | Name of the opened scene that should be saved. Could be empty if need to save the current active scene. |
+| `path` | `string` | No | Path to the scene file. Should end with ".unity". If null or empty save to the existed scene asset file. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "openedSceneName": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/scene-set-active/SKILL.md
+++ b/.gemini/skills/scene-set-active/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: scene-set-active
+description: Set the specified opened scene as the active scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Set Active
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-set-active --input '{
+  "sceneRef": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-set-active --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-set-active --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sceneRef` | `any` | Yes | Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "sceneRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    }
+  },
+  "required": [
+    "sceneRef"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "IsLoaded": {
+          "type": "boolean"
+        },
+        "IsDirty": {
+          "type": "boolean"
+        },
+        "IsSubScene": {
+          "type": "boolean"
+        },
+        "IsValidScene": {
+          "type": "boolean",
+          "description": "Whether this is a valid Scene. A Scene may be invalid if, for example, you tried to open a Scene that does not exist. In this case, the Scene returned from EditorSceneManager.OpenScene would return False for IsValid."
+        },
+        "RootCount": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the Scene within the project. Starts with 'Assets/'"
+        },
+        "buildIndex": {
+          "type": "integer",
+          "description": "Build index of the Scene in the Build Settings."
+        },
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0', then it will be used as 'null'."
+        }
+      },
+      "required": [
+        "IsLoaded",
+        "IsDirty",
+        "IsSubScene",
+        "IsValidScene",
+        "RootCount",
+        "buildIndex",
+        "instanceID"
+      ],
+      "description": "Scene reference. Used to find a Scene."
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.SceneDataShallow",
+        "description": "Scene reference. Used to find a Scene."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/scene-unload/SKILL.md
+++ b/.gemini/skills/scene-unload/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: scene-unload
+description: Unload scene from the Opened scenes in Unity Editor. Use 'scene-list-opened' tool to get the list of all opened scenes.
+---
+
+# Scene / Unload
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool scene-unload --input '{
+  "name": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool scene-unload --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool scene-unload --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | Name of the loaded scene. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Scene+UnloadSceneResult"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If this is '0' and 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Reference to UnityEngine.Object asset instance. It could be Material, ScriptableObject, Prefab, and any other Asset. Anything located in the Assets and Packages folders."
+    },
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Scene+UnloadSceneResult": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name of the unloaded scene."
+        },
+        "AssetObjectRef": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.AssetObjectRef",
+          "description": "Reference to the unloaded scene asset."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/screenshot-camera/SKILL.md
+++ b/.gemini/skills/screenshot-camera/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: screenshot-camera
+description: Captures a screenshot from a camera and returns it as an image. If no camera is specified, uses the Main Camera. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Camera
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-camera --input '{
+  "cameraRef": "string_value",
+  "width": 0,
+  "height": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-camera --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-camera --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `cameraRef` | `any` | No | Reference to the camera GameObject. If not specified, uses the Main Camera. |
+| `width` | `integer` | No | Width of the screenshot in pixels. |
+| `height` | `integer` | No | Height of the screenshot in pixels. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "cameraRef": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
+    },
+    "width": {
+      "type": "integer"
+    },
+    "height": {
+      "type": "integer"
+    }
+  },
+  "$defs": {
+    "System.Type": {
+      "type": "string"
+    },
+    "com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef": {
+      "type": "object",
+      "properties": {
+        "instanceID": {
+          "type": "integer",
+          "description": "instanceID of the UnityEngine.Object. If it is '0' and 'path', 'name', 'assetPath' and 'assetGuid' is not provided, empty or null, then it will be used as 'null'. Priority: 1 (Recommended)"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of a GameObject in the hierarchy Sample 'character/hand/finger/particle'. Priority: 2."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of a GameObject in hierarchy. Priority: 3."
+        },
+        "assetType": {
+          "$ref": "#/$defs/System.Type",
+          "description": "Type of the asset."
+        },
+        "assetPath": {
+          "type": "string",
+          "description": "Path to the asset within the project. Starts with 'Assets/'"
+        },
+        "assetGuid": {
+          "type": "string",
+          "description": "Unique identifier for the asset."
+        }
+      },
+      "required": [
+        "instanceID"
+      ],
+      "description": "Find GameObject in opened Prefab or in the active Scene."
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/screenshot-game-view/SKILL.md
+++ b/.gemini/skills/screenshot-game-view/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: screenshot-game-view
+description: Captures a screenshot from the Unity Editor Game View and returns it as an image. Reads the Game View's own render texture directly via the Unity Editor API. The image size matches the current Game View resolution. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Game View
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-game-view --input '{
+  "nothing": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-game-view --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-game-view --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nothing` | `string` | No |  |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "nothing": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/screenshot-scene-view/SKILL.md
+++ b/.gemini/skills/screenshot-scene-view/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: screenshot-scene-view
+description: Captures a screenshot from the Unity Editor Scene View and returns it as an image. Returns the image directly for visual inspection by the LLM.
+---
+
+# Screenshot / Scene View
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool screenshot-scene-view --input '{
+  "width": 0,
+  "height": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool screenshot-scene-view --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool screenshot-scene-view --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `width` | `integer` | No | Width of the screenshot in pixels. |
+| `height` | `integer` | No | Height of the screenshot in pixels. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "width": {
+      "type": "integer"
+    },
+    "height": {
+      "type": "integer"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/script-delete/SKILL.md
+++ b/.gemini/skills/script-delete/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: script-delete
+description: Delete the script file(s). Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. Use 'script-read' tool to read existing script files first.
+---
+
+# Script / Delete
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-delete --input '{
+  "files": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-delete --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-delete --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `files` | `any` | Yes | File paths to the files. Sample: "Assets/Scripts/MyScript.cs". |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "files": {
+      "$ref": "#/$defs/System.String[]"
+    }
+  },
+  "$defs": {
+    "System.String[]": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "files"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/script-execute/SKILL.md
+++ b/.gemini/skills/script-execute/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: script-execute
+description: Compiles and executes C# code dynamically using Roslyn. The provided code must define a class with a static method to execute.
+---
+
+# Script / Execute
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-execute --input '{
+  "csharpCode": "string_value",
+  "className": "string_value",
+  "methodName": "string_value",
+  "parameters": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-execute --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-execute --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `csharpCode` | `string` | Yes | C# code that compiles and executes immediately. It won't be stored as a script in the project. It is temporary one shot C# code execution using Roslyn. IMPORTANT: The code must define a class (e.g., 'public class Script') with a static method (e.g., 'public static object Main()'). Do NOT use top-level statements or code outside a class. Top-level statements are not supported and will cause compilation errors. |
+| `className` | `string` | No | The name of the class containing the method to execute. |
+| `methodName` | `string` | No | The name of the method to execute. It must be a static method in the class provided above. |
+| `parameters` | `any` | No | Serialized parameters to pass to the method. If the method does not require parameters, leave this empty. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "csharpCode": {
+      "type": "string"
+    },
+    "className": {
+      "type": "string"
+    },
+    "methodName": {
+      "type": "string"
+    },
+    "parameters": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMemberList"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "csharpCode"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMemberList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.SerializedMember": {
+      "type": "object",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Full type name. Eg: 'System.String', 'System.Int32', 'UnityEngine.Vector3', etc."
+        },
+        "name": {
+          "type": "string",
+          "description": "Object name."
+        },
+        "value": {
+          "description": "Value of the object, serialized as a non stringified JSON element. Can be null if the value is not set. Can be default value if the value is an empty object or array json."
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested field value."
+          },
+          "description": "Fields of the object, serialized as a list of 'SerializedMember'."
+        },
+        "props": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.SerializedMember",
+            "description": "Nested property value."
+          },
+          "description": "Properties of the object, serialized as a list of 'SerializedMember'."
+        }
+      },
+      "required": [
+        "typeName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/script-read/SKILL.md
+++ b/.gemini/skills/script-read/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: script-read
+description: Reads the content of a script file and returns it as a string. Use 'script-update-or-create' tool to update or create script files.
+---
+
+# Script / Read
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-read --input '{
+  "filePath": "string_value",
+  "lineFrom": 0,
+  "lineTo": 0
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-read --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-read --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filePath` | `string` | Yes | The path to the file. Sample: "Assets/Scripts/MyScript.cs". |
+| `lineFrom` | `integer` | No | The line number to start reading from (1-based). |
+| `lineTo` | `integer` | No | The line number to stop reading at (1-based, -1 for all lines). |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filePath": {
+      "type": "string"
+    },
+    "lineFrom": {
+      "type": "integer"
+    },
+    "lineTo": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "filePath"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/script-update-or-create/SKILL.md
+++ b/.gemini/skills/script-update-or-create/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: script-update-or-create
+description: Updates or creates script file with the provided C# code. Does AssetDatabase.Refresh() at the end. Provides compilation error details if the code has syntax errors. Use 'script-read' tool to read existing script files first.
+---
+
+# Script / Update or Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool script-update-or-create --input '{
+  "filePath": "string_value",
+  "content": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool script-update-or-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool script-update-or-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filePath` | `string` | Yes | The path to the file. Sample: "Assets/Scripts/MyScript.cs". |
+| `content` | `string` | Yes | C# code - content of the file. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "filePath": {
+      "type": "string"
+    },
+    "content": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "filePath",
+    "content"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/tests-run/SKILL.md
+++ b/.gemini/skills/tests-run/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: tests-run
+description: Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development.
+---
+
+# Tests / Run
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tests-run --input '{
+  "testMode": "string_value",
+  "testAssembly": "string_value",
+  "testNamespace": "string_value",
+  "testClass": "string_value",
+  "testMethod": "string_value",
+  "includePassingTests": false,
+  "includeMessages": false,
+  "includeStacktrace": false,
+  "includeLogs": false,
+  "logType": "string_value",
+  "includeLogsStacktrace": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tests-run --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tests-run --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `testMode` | `string` | No | Test mode to run. Options: 'EditMode', 'PlayMode'. Default: 'EditMode' |
+| `testAssembly` | `string` | No | Specific test assembly name to run (optional). Example: 'Assembly-CSharp-Editor-testable' |
+| `testNamespace` | `string` | No | Specific test namespace to run (optional). Example: 'MyTestNamespace' |
+| `testClass` | `string` | No | Specific test class name to run (optional). Example: 'MyTestClass' |
+| `testMethod` | `string` | No | Specific fully qualified test method to run (optional). Example: 'MyTestNamespace.FixtureName.TestName' |
+| `includePassingTests` | `boolean` | No | Include details for all tests, both passing and failing (default: false). If you just need details for failing tests, set to false. |
+| `includeMessages` | `boolean` | No | Include test result messages in the test results (default: true). If you just need pass/fail status, set to false. |
+| `includeStacktrace` | `boolean` | No | Include stack traces in the test results (default: false). |
+| `includeLogs` | `boolean` | No | Include console logs in the test results (default: false). |
+| `logType` | `string` | No | Log type filter for console logs. Options: 'Log', 'Warning', 'Assert', 'Error', 'Exception'. (default: 'Warning') |
+| `includeLogsStacktrace` | `boolean` | No | Include stack traces for console logs in the test results (default: false). This is huge amount of data, use only if really needed. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "testMode": {
+      "type": "string",
+      "enum": [
+        "EditMode",
+        "PlayMode"
+      ]
+    },
+    "testAssembly": {
+      "type": "string"
+    },
+    "testNamespace": {
+      "type": "string"
+    },
+    "testClass": {
+      "type": "string"
+    },
+    "testMethod": {
+      "type": "string"
+    },
+    "includePassingTests": {
+      "type": "boolean"
+    },
+    "includeMessages": {
+      "type": "boolean"
+    },
+    "includeStacktrace": {
+      "type": "boolean"
+    },
+    "includeLogs": {
+      "type": "boolean"
+    },
+    "logType": {
+      "type": "string",
+      "enum": [
+        "Error",
+        "Assert",
+        "Warning",
+        "Log",
+        "Exception"
+      ]
+    },
+    "includeLogsStacktrace": {
+      "type": "boolean"
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestRunResponse"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestSummaryData": {
+      "type": "object",
+      "properties": {
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Unknown",
+            "Passed",
+            "Failed"
+          ]
+        },
+        "TotalTests": {
+          "type": "integer"
+        },
+        "PassedTests": {
+          "type": "integer"
+        },
+        "FailedTests": {
+          "type": "integer"
+        },
+        "SkippedTests": {
+          "type": "integer"
+        },
+        "Duration": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Status",
+        "TotalTests",
+        "PassedTests",
+        "FailedTests",
+        "SkippedTests",
+        "Duration"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Passed",
+            "Failed",
+            "Skipped"
+          ]
+        },
+        "Duration": {
+          "type": "string"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "StackTrace": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Status",
+        "Duration"
+      ]
+    },
+    "System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry>": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry": {
+      "type": "object",
+      "properties": {
+        "Condition": {
+          "type": "string"
+        },
+        "StackTrace": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Error",
+            "Assert",
+            "Warning",
+            "Log",
+            "Exception"
+          ]
+        },
+        "Timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "LogLevel": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Type",
+        "Timestamp"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestRunResponse": {
+      "type": "object",
+      "properties": {
+        "Summary": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestSummaryData",
+          "description": "Summary of the test run including total, passed, failed, and skipped counts."
+        },
+        "Results": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestResultData>",
+          "description": "List of individual test results with details about each test."
+        },
+        "Logs": {
+          "$ref": "#/$defs/System.Collections.Generic.List<com.IvanMurzak.Unity.MCP.Editor.API.TestRunner.TestLogEntry>",
+          "description": "Log entries captured during test execution."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/tool-list/SKILL.md
+++ b/.gemini/skills/tool-list/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: tool-list
+description: List all available MCP tools. Optionally filter by regex across tool names, descriptions, and arguments.
+---
+
+# Tool / List
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tool-list --input '{
+  "regexSearch": "string_value",
+  "includeDescription": "string_value",
+  "includeInputs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tool-list --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tool-list --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `regexSearch` | `string` | No | Regex pattern to filter tools. Matches against tool name, description, and argument names and descriptions. |
+| `includeDescription` | `any` | No | Include tool descriptions in the result. Default: false |
+| `includeInputs` | `any` | No | Include input arguments in the result. Default: None |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "regexSearch": {
+      "type": "string"
+    },
+    "includeDescription": {
+      "$ref": "#/$defs/System.Boolean"
+    },
+    "includeInputs": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputRequest"
+    }
+  },
+  "$defs": {
+    "System.Boolean": {
+      "type": "boolean"
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputRequest": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Inputs",
+        "InputsWithDescription"
+      ],
+      "description": "Specifies what to include for tool input arguments."
+    }
+  }
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData[]"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Tool name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Tool description."
+        },
+        "inputs": {
+          "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData[]",
+          "description": "Tool input arguments."
+        }
+      },
+      "description": "MCP tool information."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData",
+        "description": "MCP tool input argument."
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInputData": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Argument name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Argument description."
+        }
+      },
+      "description": "MCP tool input argument."
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ToolInfoData",
+        "description": "MCP tool information."
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/tool-set-enabled-state/SKILL.md
+++ b/.gemini/skills/tool-set-enabled-state/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: tool-set-enabled-state
+description: Enable or disable MCP tools by name. Allows controlling which tools are available for the AI agent.
+---
+
+# Tool / Set Enabled State
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool tool-set-enabled-state --input '{
+  "tools": "string_value",
+  "includeLogs": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool tool-set-enabled-state --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool tool-set-enabled-state --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `tools` | `any` | Yes | Array of tools with their desired enabled state. |
+| `includeLogs` | `any` | No | Include operation logs in the result. Default: false |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "tools": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData[]"
+    },
+    "includeLogs": {
+      "$ref": "#/$defs/System.Boolean"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name of the MCP tool to enable or disable."
+        },
+        "Enabled": {
+          "type": "boolean",
+          "description": "Whether the tool should be enabled (true) or disabled (false)."
+        }
+      },
+      "required": [
+        "Enabled"
+      ]
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData[]": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+InputData"
+      }
+    },
+    "System.Boolean": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "tools"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ResultData"
+    }
+  },
+  "$defs": {
+    "com.IvanMurzak.ReflectorNet.Model.Logs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.LogEntry"
+      }
+    },
+    "com.IvanMurzak.ReflectorNet.Model.LogEntry": {
+      "type": "object",
+      "properties": {
+        "Depth": {
+          "type": "integer"
+        },
+        "Message": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Trace",
+            "Debug",
+            "Info",
+            "Success",
+            "Warning",
+            "Error",
+            "Critical"
+          ]
+        }
+      },
+      "required": [
+        "Depth",
+        "Type"
+      ]
+    },
+    "System.Collections.Generic.Dictionary<System.String,System.Boolean>": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "com.IvanMurzak.Unity.MCP.Editor.API.Tool_Tool+ResultData": {
+      "type": "object",
+      "properties": {
+        "Logs": {
+          "$ref": "#/$defs/com.IvanMurzak.ReflectorNet.Model.Logs",
+          "description": "Optional operation logs. Only included when 'includeLogs' is true."
+        },
+        "Success": {
+          "$ref": "#/$defs/System.Collections.Generic.Dictionary<System.String,System.Boolean>",
+          "description": "Result of each tool operation. Key: original input name as provided by the caller (case preserved as-is). Value: true if the enable/disable operation completed successfully, false if the name was unknown, ambiguous, or empty."
+        }
+      }
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/type-get-json-schema/SKILL.md
+++ b/.gemini/skills/type-get-json-schema/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: type-get-json-schema
+description: Generates a JSON Schema for a given C# type name using reflection. Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. The type must be present in any loaded assembly. Use the full type name (e.g. 'UnityEngine.Vector3') for best results.
+---
+
+# Type / Get Json Schema
+
+## How to Call
+
+```bash
+unity-mcp-cli run-tool type-get-json-schema --input '{
+  "typeName": "string_value",
+  "descriptionMode": "string_value",
+  "propertyDescriptionMode": "string_value",
+  "includeNestedTypes": false,
+  "writeIndented": false
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-tool type-get-json-schema --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-tool type-get-json-schema --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `typeName` | `string` | Yes | Full C# type name to generate the schema for. Examples: 'System.String', 'UnityEngine.Vector3', 'System.Collections.Generic.List<System.Int32>'. Simple names like 'Vector3' are also accepted when unambiguous. |
+| `descriptionMode` | `string` | No | Controls the type-level 'description' field. Include: keep on the target type only. IncludeRecursively: keep on the target type and inside $defs entries. Ignore: strip all type-level descriptions. Default: Ignore. |
+| `propertyDescriptionMode` | `string` | No | Controls 'description' fields on properties, fields, and array items. Include: keep on the target type's own properties/items only. IncludeRecursively: keep on all properties/items including those inside $defs entries. Ignore: strip all property/item descriptions. Default: Ignore. |
+| `includeNestedTypes` | `boolean` | No | When true, complex nested types are extracted into '$defs' and referenced via '$ref' instead of being inlined. Useful for large or recursive types. Default: false. |
+| `writeIndented` | `boolean` | No | Whether to format the output JSON with indentation for readability. Default: false. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "typeName": {
+      "type": "string"
+    },
+    "descriptionMode": {
+      "type": "string",
+      "enum": [
+        "Include",
+        "IncludeRecursively",
+        "Ignore"
+      ]
+    },
+    "propertyDescriptionMode": {
+      "type": "string",
+      "enum": [
+        "Include",
+        "IncludeRecursively",
+        "Ignore"
+      ]
+    },
+    "includeNestedTypes": {
+      "type": "boolean"
+    },
+    "writeIndented": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "typeName"
+  ]
+}
+```
+
+## Output
+
+### Output JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ]
+}
+```
+

--- a/.gemini/skills/unity-initial-setup/SKILL.md
+++ b/.gemini/skills/unity-initial-setup/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: unity-initial-setup
+description: |-
+  Provides an initial setup for AI Skills, `unity-mcp-cli` command line tool installation
+  and everything else that is helpful to set up at the start of the project. Essential packages,
+  and basic configurations.
+---
+
+# AI Game Developer — Initial Setup
+
+This guide walks through installing the `unity-mcp-cli` command-line tool and using it to set
+up a Unity project with AI Skills and MCP integration.
+
+---
+
+## Prerequisites
+
+### Install Node.js
+
+`unity-mcp-cli` requires **Node.js ^20.19.0 || >=22.12.0** (Node 21.x is not supported). If you don't have Node.js installed:
+
+Download the installer from https://nodejs.org/ and run it, or use a package manager:
+```
+winget install OpenJS.NodeJS.LTS
+```
+
+After installation, verify both `node` and `npm` are available:
+```
+node --version
+npm --version
+```
+
+---
+
+## Install `unity-mcp-cli` Globally
+
+Install the CLI globally so the `unity-mcp-cli` command is available system-wide:
+
+```bash
+npm install -g unity-mcp-cli
+```
+
+Verify installation:
+```bash
+unity-mcp-cli --version
+```
+
+
+> **Alternative**: Run any command without installing globally using `npx`:
+> ```bash
+> npx unity-mcp-cli --help
+> ```
+
+---
+
+## Quick Start — Full Project Setup
+
+### 1. Install the Unity-MCP Plugin
+
+Add the plugin to an existing Unity project:
+```bash
+unity-mcp-cli install-plugin /path/to/unity/project
+```
+
+### 2. Configure MCP Tools
+
+Enable all tools, prompts, and resources:
+```bash
+unity-mcp-cli configure /path/to/unity/project \
+  --enable-all-tools \
+  --enable-all-prompts \
+  --enable-all-resources
+```
+
+### 3. Set Up MCP for Your AI Agent
+
+Configure MCP integration for your AI agent (e.g., Claude Code, Cursor, Copilot):
+```bash
+unity-mcp-cli setup-mcp claude-code /path/to/unity/project
+```
+
+List all supported agents:
+```bash
+unity-mcp-cli setup-mcp --list
+```
+
+### 4. Generate AI Skills
+
+Generate skill files for your AI agent (requires Unity Editor to be running with the plugin):
+```bash
+unity-mcp-cli setup-skills claude-code /path/to/unity/project
+```
+
+### 5. Open Unity with MCP Connection
+
+```bash
+unity-mcp-cli open /path/to/unity/project
+```
+
+---
+
+## Common Commands Reference
+
+| Command | Description |
+|---|---|
+| `unity-mcp-cli install-plugin <path>` | Install Unity-MCP plugin into a project |
+| `unity-mcp-cli remove-plugin <path>` | Remove Unity-MCP plugin from a project |
+| `unity-mcp-cli configure <path> --list` | List current MCP configuration |
+| `unity-mcp-cli setup-mcp <agent> <path>` | Write MCP config for an AI agent |
+| `unity-mcp-cli setup-skills <agent> <path>` | Generate skill files for an AI agent |
+| `unity-mcp-cli create-project <path>` | Create a new Unity project |
+| `unity-mcp-cli install-unity <version>` | Install a Unity Editor version |
+| `unity-mcp-cli open <path>` | Open a Unity project in the Editor |
+| `unity-mcp-cli run-tool <tool> <path>` | Execute an MCP tool via HTTP API |
+
+Add `--verbose` to any command for detailed diagnostic output.
+
+---
+
+## Troubleshooting
+
+- **`npm` not found**: Node.js is not installed or not in your PATH. Reinstall Node.js and restart your terminal.
+- **Plugin not appearing in Unity**: After `install-plugin`, open the project in Unity Editor. The package manager resolves dependencies on project open.
+- **Skills generation fails**: Ensure Unity Editor is running with the MCP plugin installed and connected before running `setup-skills`.

--- a/.gemini/skills/unity-skill-create/SKILL.md
+++ b/.gemini/skills/unity-skill-create/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: unity-skill-create
+description: |-
+  Create a new skill using C# code. It will be added into the project as a .cs file and compiled by Unity. The skill will be available for use after compilation.
+  
+  It must be a partial class decorated with [McpPluginToolType]. Each tool method must be decorated with [McpPluginTool]. The class name should match the file name. All Unity API calls must use com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(). Return a data model for structured output, or void for side-effect-only operations. 
+  
+  Full sample:
+  ```csharp
+  #nullable enable
+  using System;
+  using System.ComponentModel;
+  using com.IvanMurzak.McpPlugin;
+  using com.IvanMurzak.ReflectorNet.Utils;
+  using com.IvanMurzak.Unity.MCP.Editor.Utils;
+  using com.IvanMurzak.Unity.MCP.Runtime.Data;
+  using UnityEditor;
+  using UnityEngine;
+  
+  namespace com.IvanMurzak.Unity.MCP.Editor.API
+  {
+      [McpPluginToolType]
+      public partial class Tool_Sample
+      {
+          [McpPluginTool("sample-get", Title = "Sample / Get")]
+          [Description("Finds a GameObject and returns its ref data.")]
+          public GameObjectRef Get
+          (
+              [Description("Name of the GameObject to find.")]
+              string name
+          )
+          {
+              return MainThread.Instance.Run(() =>
+              {
+                  var go = GameObject.Find(name)
+                      ?? throw new ArgumentException($"GameObject '{name}' not found.", nameof(name));
+  
+                  return new GameObjectRef(go);
+              });
+          }
+  
+          [McpPluginTool("sample-rename", Title = "Sample / Rename")]
+          [Description("Renames a GameObject.")]
+          public void Rename
+          (
+              [Description("Current name of the GameObject.")]
+              string name,
+              [Description("New name to assign.")]
+              string newName
+          )
+          {
+              MainThread.Instance.Run(() =>
+              {
+                  var go = GameObject.Find(name)
+                      ?? throw new ArgumentException($"GameObject '{name}' not found.", nameof(name));
+  
+                  go.name = newName;
+                  EditorUtility.SetDirty(go);
+                  AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+                  EditorUtils.RepaintAllEditorWindows();
+              });
+          }
+      }
+  }
+  ```
+  ## Suggestions
+  
+  ### Refresh UI after visual changes
+  If the skill modifies anything visually in the Unity Editor (GameObjects, components, materials, etc.), call these two lines at the end of the tool method to apply changes to the UI immediately:
+  ```csharp
+  AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+  EditorUtils.RepaintAllEditorWindows();
+  ```
+  
+  ### Refresh AssetDatabase after asset or script changes
+  If the skill creates, modifies, or deletes any asset file or .cs script on disk outside of Unity API, call this inside a `MainThread.Instance.Run()` block to ensure Unity picks up the changes:
+  ```csharp
+  MainThread.Instance.Run(() =>
+  {
+      AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+  });
+  ```
+  
+  ### Use processing mechanic for long-running or domain-reload operations
+  Some operations take time to complete and may trigger a Unity domain reload (e.g. writing a .cs script, switching play mode, running tests, adding a package). In these cases the tool must NOT block and wait — instead it must:
+  1. Accept a `[RequestID] string? requestId` parameter.
+  2. Return `ResponseCallTool.Processing("...").SetRequestID(requestId)` immediately.
+  3. Schedule the actual work asynchronously via `MainThread.Instance.RunAsync(async () => { await Task.Yield(); ... })`.
+  4. When the operation finishes, send the final result by calling:
+  ```csharp
+  _ = UnityMcpPluginEditor.NotifyToolRequestCompleted(new RequestToolCompletedData
+  {
+      RequestId = requestId,
+      Result = ResponseCallTool.Success("Operation completed.").SetRequestID(requestId)
+  });
+  ```
+  If the operation may survive a domain reload (e.g. a .cs file was saved and Unity will recompile), use `ScriptUtils.SchedulePostCompilationNotification(requestId, filePath, operationType)` instead of calling `NotifyToolRequestCompleted` directly — it persists the pending notification to `SessionState` and sends it automatically after the domain reload completes. For package install/removal or other non-compilation domain reloads use `PackageUtils.SchedulePostDomainReloadNotification(requestId, label, action, expectedResult)` the same way.
+  
+  ### Return structured data with a typed response
+  Prefer returning a structured data model over a plain string so the AI can parse individual fields. Declare a nested class with `[Description]` on each property and use `ResponseCallValueTool<T>` as return type:
+  ```csharp
+  // Return type:
+  public ResponseCallValueTool<MyResult> MyTool(...)
+  {
+      return ResponseCallValueTool<MyResult>.Success(new MyResult
+      {
+          Name = go.name,
+          InstanceID = go.GetInstanceID()
+      }).SetRequestID(requestId);
+  }
+  
+  // Data model:
+  public class MyResult
+  {
+      [Description("Name of the GameObject.")]
+      public string? Name { get; set; }
+  
+      [Description("Unity instance ID of the GameObject.")]
+      public int InstanceID { get; set; }
+  }
+  ```
+  For simpler cases that do not need async/processing, you may return the model directly (without `ResponseCallValueTool<T>`) and Unity-MCP will wrap it automatically.
+  
+  ### Validate inputs early and throw clearly
+  Always validate required parameters at the top of the method before any Unity API calls. Throw `ArgumentException` or `InvalidOperationException` with descriptive messages so the AI knows exactly what went wrong and can self-correct:
+  ```csharp
+  if (string.IsNullOrEmpty(name))
+      throw new ArgumentException("Name cannot be null or empty.", nameof(name));
+  ```
+  
+  ### Always use MainThread for Unity API calls
+  All Unity API calls (including `GameObject.Find`, `AssetDatabase`, `EditorUtility`, etc.) MUST run on the main thread. Wrap them in `MainThread.Instance.Run(() => { ... })` for synchronous operations, or `MainThread.Instance.RunAsync(async () => { ... })` when you need to await inside.
+---
+
+# Skill (Tool) / Create
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool unity-skill-create --input '{
+  "path": "string_value",
+  "code": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-create --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-create --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | Yes | Path for the C# (.cs) file to be created. Sample: "Assets/Skills/MySkill.cs".
+CRITICAL — Assembly Definition placement: If the project uses Assembly Definition files (.asmdef), you MUST place the script inside a folder that belongs to an assembly definition which already references all required dependencies (e.g. com.IvanMurzak.McpPlugin, UnityEditor, UnityEngine). Placing the file in the wrong assembly will cause compile errors due to missing type references. Before choosing a path, inspect existing .asmdef files with the assets-find tool to identify the correct assembly folder. |
+| `code` | `string` | Yes | C# code for the skill tool. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "code": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "path",
+    "code"
+  ]
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.gemini/skills/unity-skill-generate/SKILL.md
+++ b/.gemini/skills/unity-skill-generate/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: unity-skill-generate
+description: Generate all skills from the existed Tools in the Unity Project.
+---
+
+# Skill (Tool) / Generate All
+
+## How to Call
+
+```bash
+unity-mcp-cli run-system-tool unity-skill-generate --input '{
+  "path": "string_value"
+}'
+```
+
+> For complex input (multi-line strings, code), save the JSON to a file and use:
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-generate --input-file args.json
+> ```
+>
+> Or pipe via stdin (recommended):
+> ```bash
+> unity-mcp-cli run-system-tool unity-skill-generate --input-file - <<'EOF'
+> {"param": "value"}
+> EOF
+> ```
+
+
+### Troubleshooting
+
+If `unity-mcp-cli` is not found, either install it globally (`npm install -g unity-mcp-cli`) or use `npx unity-mcp-cli` instead.
+Read the /unity-initial-setup skill for detailed installation instructions.
+
+## Input
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | `string` | No | Path to the skills folder. If null or empty, the default path will be used. |
+
+### Input JSON Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    }
+  }
+}
+```
+
+## Output
+
+This tool does not return structured output.
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "ai-game-developer": {
+      "headers": {
+        "Authorization": "Bearer EwkM-_n6geX1ETudpKK6AQkqxGBslHbxJJWCZ4fweGA"
+      },
+      "type": "http",
+      "url": "https://ai-game.dev/mcp"
+    }
+  }
+}

--- a/Assets/Scenes/BossLevel.unity
+++ b/Assets/Scenes/BossLevel.unity
@@ -1,0 +1,804 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &363649885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 363649888}
+  - component: {fileID: 363649887}
+  - component: {fileID: 363649886}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &363649886
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 363649885}
+  m_Enabled: 1
+--- !u!20 &363649887
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 363649885}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 1, g: 0, b: 0, a: 1}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &363649888
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 363649885}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &400619032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 400619033}
+  m_Layer: 0
+  m_Name: Boss_Arena
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &400619033
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 400619032}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1091597414}
+  - {fileID: 989832890}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &684973785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 684973789}
+  - component: {fileID: 684973788}
+  - component: {fileID: 684973787}
+  - component: {fileID: 684973786}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &684973786
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684973785}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.52, y: 0.09}
+    newSize: {x: 0.52, y: 0.09}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.0001, y: 0.0001}
+  m_EdgeRadius: 0
+--- !u!50 &684973787
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684973785}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!212 &684973788
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684973785}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 3737897332693287829, guid: d2b4ec8b2bd8ad14486b662269a92cfd, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.52, y: 0.09}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &684973789
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684973785}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &940814325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 940814327}
+  - component: {fileID: 940814326}
+  - component: {fileID: 940814328}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &940814326
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940814325}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.52, y: 0.09}
+    newSize: {x: 0.52, y: 0.09}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!4 &940814327
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940814325}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
+  m_LocalScale: {x: 20, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &940814328
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940814325}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 3737897332693287829, guid: d2b4ec8b2bd8ad14486b662269a92cfd, type: 3}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.52, y: 0.09}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &989832889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 989832890}
+  - component: {fileID: 989832891}
+  m_Layer: 0
+  m_Name: LeftWall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &989832890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 989832889}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 10, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 400619033}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &989832891
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 989832889}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &1091597413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1091597414}
+  - component: {fileID: 1091597415}
+  m_Layer: 0
+  m_Name: RightWall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1091597414
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1091597413}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 10, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 400619033}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1091597415
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1091597413}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &1999117715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1999117717}
+  - component: {fileID: 1999117716}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1999117716
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999117715}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &1999117717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999117715}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.10938166, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 363649888}
+  - {fileID: 684973789}
+  - {fileID: 940814327}
+  - {fileID: 400619033}
+  - {fileID: 1999117717}

--- a/Assets/Scenes/BossLevel.unity.meta
+++ b/Assets/Scenes/BossLevel.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af3f0d1337fa9134998e99b111edee3c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -729,6 +729,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1560140941}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &194243954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 194243956}
+  - component: {fileID: 194243955}
+  m_Layer: 0
+  m_Name: LevelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &194243955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 194243954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 996c081f43163d14fbab763a7b20633e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  levelCompleteCanvas: {fileID: 1870324372}
+  delayBeforeNextLevel: 3
+--- !u!4 &194243956
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 194243954}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &224145536
 GameObject:
   m_ObjectHideFlags: 0
@@ -4104,6 +4150,149 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &868603868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 868603869}
+  - component: {fileID: 868603871}
+  - component: {fileID: 868603870}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &868603869
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868603868}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1592799048}
+  m_Father: {fileID: 1870324376}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &868603870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868603868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &868603871
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868603868}
+  m_CullTransparentMesh: 1
+--- !u!21 &877278365
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LiberationSans SDF Material (Instance)
+  m_Shader: {fileID: 4800000, guid: fe393ace9b354375a9cb14cdbbc28be4, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 28684132378477856, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _CullMode: 0
+    - _FaceDilate: 0
+    - _GradientScale: 10
+    - _MaskSoftnessX: 0
+    - _MaskSoftnessY: 0
+    - _OutlineSoftness: 0
+    - _OutlineWidth: 0
+    - _PerspectiveFilter: 0.875
+    - _ScaleRatioA: 0.9
+    - _ScaleRatioB: 1
+    - _ScaleRatioC: 0.73125
+    - _ScaleX: 1
+    - _ScaleY: 1
+    - _ShaderFlags: 0
+    - _Sharpness: 0
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _TextureHeight: 1024
+    - _TextureWidth: 1024
+    - _UnderlayDilate: 0
+    - _UnderlayOffsetX: 0
+    - _UnderlayOffsetY: 0
+    - _UnderlaySoftness: 0
+    - _VertexOffsetX: 0
+    - _VertexOffsetY: 0
+    - _WeightBold: 0.75
+    - _WeightNormal: 0
+    m_Colors:
+    - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!1 &905995863
 GameObject:
   m_ObjectHideFlags: 0
@@ -45278,6 +45467,157 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1592799047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1592799048}
+  - component: {fileID: 1592799051}
+  - component: {fileID: 1592799050}
+  - component: {fileID: 1592799049}
+  m_Layer: 0
+  m_Name: LevelCompleteText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1592799048
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592799047}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 868603869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1592799049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592799047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6366ee97f6b541449155028b9487355a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1592799050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592799047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Level Complete
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 877278365}
+  m_fontSharedMaterials:
+  - {fileID: 877278365}
+  m_fontMaterial: {fileID: 877278365}
+  m_fontMaterials:
+  - {fileID: 877278365}
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1592799051
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1592799047}
+  m_CullTransparentMesh: 1
 --- !u!1 &1699789650
 GameObject:
   m_ObjectHideFlags: 0
@@ -46199,6 +46539,108 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.15, y: 0.1}
   m_EdgeRadius: 0
+--- !u!1 &1870324372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1870324376}
+  - component: {fileID: 1870324375}
+  - component: {fileID: 1870324374}
+  - component: {fileID: 1870324373}
+  m_Layer: 0
+  m_Name: LevelCompleteUI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1870324373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870324372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1870324374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870324372}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1870324375
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870324372}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1870324376
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870324372}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 868603869}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1917595811
 GameObject:
   m_ObjectHideFlags: 0
@@ -46690,3 +47132,5 @@ SceneRoots:
   - {fileID: 569565129}
   - {fileID: 358912369}
   - {fileID: 49254505}
+  - {fileID: 194243956}
+  - {fileID: 1870324376}

--- a/Assets/Scripts/BossArenaTrigger.cs
+++ b/Assets/Scripts/BossArenaTrigger.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class BossArenaTrigger : MonoBehaviour
+{
+    [Header("Arena Setup")]
+    [SerializeField] private GameObject[] arenaWalls;
+    [SerializeField] private GameObject bossGameObject;
+    
+    [Header("Audio")]
+    [SerializeField] private AudioSource musicSource;
+    [SerializeField] private AudioClip bossMusicClip;
+
+    private bool hasTriggered = false;
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (!hasTriggered && other.CompareTag("Player"))
+        {
+            ActivateArena();
+        }
+    }
+
+    private void ActivateArena()
+    {
+        hasTriggered = true;
+
+        // Lock the player inside by enabling wall colliders
+        foreach (GameObject wall in arenaWalls)
+        {
+            if (wall != null)
+            {
+                BoxCollider2D wallCollider = wall.GetComponent<BoxCollider2D>();
+                if (wallCollider != null)
+                {
+                    wallCollider.enabled = true;
+                }
+                else
+                {
+                    // If no BoxCollider2D, just activate the GameObject as a fallback
+                    wall.SetActive(true);
+                }
+            }
+        }
+
+        // Activate the Boss
+        if (bossGameObject != null)
+        {
+            bossGameObject.SetActive(true);
+        }
+
+        // Play dramatic music
+        if (musicSource != null && bossMusicClip != null)
+        {
+            musicSource.clip = bossMusicClip;
+            musicSource.loop = true;
+            musicSource.Play();
+        }
+
+        Debug.Log("Boss Arena Activated!");
+    }
+}

--- a/Assets/Scripts/BossArenaTrigger.cs.meta
+++ b/Assets/Scripts/BossArenaTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10e2473eb815bbd4ea12be271e242d2f

--- a/Assets/Scripts/BossDefeatedTrigger.cs
+++ b/Assets/Scripts/BossDefeatedTrigger.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class BossDefeatedTrigger : MonoBehaviour
+{
+    private void OnDestroy()
+    {
+        // Example: Trigger when boss is destroyed
+        if (!gameObject.scene.isLoaded) return; // Ignore when scene is unloading
+
+        LevelManager levelManager = Object.FindFirstObjectByType<LevelManager>();
+        if (levelManager != null)
+        {
+            levelManager.BossDefeated();
+        }
+    }
+
+    // Manual trigger for testing
+    [ContextMenu("Trigger Boss Defeated")]
+    public void TriggerBossDefeated()
+    {
+        LevelManager levelManager = Object.FindFirstObjectByType<LevelManager>();
+        if (levelManager != null)
+        {
+            levelManager.BossDefeated();
+        }
+    }
+}

--- a/Assets/Scripts/BossDefeatedTrigger.cs.meta
+++ b/Assets/Scripts/BossDefeatedTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29a698c3923df4a48b1759ab946b8d45

--- a/Assets/Scripts/GameVictoryManager.cs
+++ b/Assets/Scripts/GameVictoryManager.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Collections;
+
+public class GameVictoryManager : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private GameObject victoryCanvas;
+    
+    [Header("FX References")]
+    [SerializeField] private GameObject confettiPrefab;
+    [SerializeField] private int confettiCount = 5;
+    [SerializeField] private float spawnRadius = 3f;
+
+    [Header("Settings")]
+    [SerializeField] private float slowMotionScale = 0.5f;
+    [SerializeField] private float finalPauseDelay = 2.0f;
+
+    private bool hasWon = false;
+
+    public void OnFinalBossDefeated()
+    {
+        if (hasWon) return;
+        hasWon = true;
+
+        StartCoroutine(VictorySequence());
+    }
+
+    private IEnumerator VictorySequence()
+    {
+        // 1. Slow down time
+        Time.timeScale = slowMotionScale;
+        Time.fixedDeltaTime = 0.02f * Time.timeScale; // Keep physics stable
+
+        // 2. Spawn Confetti around the player
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null && confettiPrefab != null)
+        {
+            for (int i = 0; i < confettiCount; i++)
+            {
+                Vector3 spawnPos = player.transform.position + (Vector3)Random.insideUnitCircle * spawnRadius;
+                Instantiate(confettiPrefab, spawnPos, Quaternion.identity);
+            }
+        }
+
+        // 3. Wait for 2 seconds (unscaled time because timeScale is 0.5)
+        yield return new WaitForSecondsRealtime(finalPauseDelay);
+
+        // 4. Pause the game and show UI
+        Time.timeScale = 0f;
+        if (victoryCanvas != null)
+        {
+            victoryCanvas.SetActive(true);
+        }
+    }
+
+    // Button Functions
+    public void LoadMainMenu()
+    {
+        Time.timeScale = 1f;
+        SceneManager.LoadScene("MineMenu"); // Based on your file structure
+    }
+
+    public void QuitGame()
+    {
+        Debug.Log("Quitting Game...");
+        Application.Quit();
+    }
+}

--- a/Assets/Scripts/GameVictoryManager.cs.meta
+++ b/Assets/Scripts/GameVictoryManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c13d520fac711504d9422cdd74f07e29

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Collections;
+
+public class LevelManager : MonoBehaviour
+{
+    [SerializeField] private GameObject levelCompleteCanvas;
+    [SerializeField] private float delayBeforeNextLevel = 3.0f;
+
+    public void BossDefeated()
+    {
+        if (levelCompleteCanvas != null)
+        {
+            levelCompleteCanvas.SetActive(true);
+        }
+
+        StartCoroutine(LoadNextLevelAfterDelay());
+    }
+
+    private IEnumerator LoadNextLevelAfterDelay()
+    {
+        yield return new WaitForSeconds(delayBeforeNextLevel);
+
+        int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+        int nextSceneIndex = (currentSceneIndex + 1) % SceneManager.sceneCountInBuildSettings;
+
+        // Optionally, check if we're at the last level or need a specific range
+        // For Level 1 to 5, we can use a simpler approach or a dedicated level index
+        SceneManager.LoadScene(nextSceneIndex);
+    }
+}

--- a/Assets/Scripts/LevelManager.cs.meta
+++ b/Assets/Scripts/LevelManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 996c081f43163d14fbab763a7b20633e

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -44,6 +44,23 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
-  }
+    "com.unity.modules.xr": "1.0.0",
+    "com.ivanmurzak.unity.mcp": "0.64.0",
+    "com.ivanmurzak.unity.mcp.animation": "1.1.23",
+    "com.ivanmurzak.unity.mcp.particlesystem": "1.0.50"
+  },
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.com",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.ivanmurzak",
+        "extensions.unity",
+        "org.nuget.com.ivanmurzak",
+        "org.nuget.microsoft",
+        "org.nuget.system",
+        "org.nuget.r3"
+      ]
+    }
+  ]
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,47 @@
 {
   "dependencies": {
+    "com.ivanmurzak.unity.mcp": {
+      "version": "0.64.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.test-framework": "1.1.33",
+        "extensions.unity.playerprefsex": "2.1.3",
+        "org.nuget.microsoft.aspnetcore.signalr.client": "10.0.3",
+        "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "10.0.3",
+        "org.nuget.microsoft.bcl.memory": "10.0.3",
+        "org.nuget.microsoft.codeanalysis.csharp": "4.14.0",
+        "org.nuget.microsoft.extensions.caching.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.hosting.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.logging": "10.0.3",
+        "org.nuget.microsoft.extensions.logging.abstractions": "10.0.3",
+        "org.nuget.r3": "1.3.0",
+        "org.nuget.system.text.json": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "com.ivanmurzak.unity.mcp.animation": {
+      "version": "1.1.23",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.ivanmurzak.unity.mcp": "0.63.4",
+        "com.unity.modules.animation": "1.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "com.ivanmurzak.unity.mcp.particlesystem": {
+      "version": "1.0.50",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.ivanmurzak.unity.mcp": "0.63.4",
+        "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
     "com.unity.2d.animation": {
       "version": "10.2.0",
       "depth": 1,
@@ -341,6 +383,450 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "extensions.unity.playerprefsex": {
+      "version": "2.1.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.connections.abstractions": {
+      "version": "10.0.3",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.features": "10.0.3",
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.system.io.pipelines": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.http.connections.client": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.http.connections.common": "10.0.3",
+        "org.nuget.microsoft.extensions.logging.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.options": "10.0.3",
+        "org.nuget.system.net.serversentevents": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.http.connections.common": {
+      "version": "10.0.3",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.connections.abstractions": "10.0.3",
+        "org.nuget.system.text.json": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.signalr.client": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.signalr.client.core": "10.0.3",
+        "org.nuget.microsoft.aspnetcore.http.connections.client": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.signalr.client.core": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "10.0.3",
+        "org.nuget.microsoft.aspnetcore.signalr.common": "10.0.3",
+        "org.nuget.microsoft.bcl.timeprovider": "10.0.3",
+        "org.nuget.microsoft.extensions.dependencyinjection": "10.0.3",
+        "org.nuget.microsoft.extensions.logging": "10.0.3",
+        "org.nuget.system.threading.channels": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.signalr.common": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.connections.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.options": "10.0.3",
+        "org.nuget.system.text.json": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.aspnetcore.signalr.common": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.bcl.asyncinterfaces": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.bcl.memory": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.bcl.timeprovider": {
+      "version": "10.0.3",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.codeanalysis.analyzers": {
+      "version": "3.11.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.codeanalysis.common": {
+      "version": "4.14.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.codeanalysis.analyzers": "3.11.0",
+        "org.nuget.system.collections.immutable": "9.0.0",
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.reflection.metadata": "9.0.0",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0",
+        "org.nuget.system.text.encoding.codepages": "7.0.0",
+        "org.nuget.system.threading.tasks.extensions": "4.5.4",
+        "org.nuget.system.buffers": "4.5.1",
+        "org.nuget.system.numerics.vectors": "4.5.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.codeanalysis.csharp": {
+      "version": "4.14.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.codeanalysis.common": "4.14.0",
+        "org.nuget.microsoft.codeanalysis.analyzers": "3.11.0",
+        "org.nuget.system.buffers": "4.5.1",
+        "org.nuget.system.collections.immutable": "9.0.0",
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.numerics.vectors": "4.5.0",
+        "org.nuget.system.reflection.metadata": "9.0.0",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0",
+        "org.nuget.system.text.encoding.codepages": "7.0.0",
+        "org.nuget.system.threading.tasks.extensions": "4.5.4"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.caching.abstractions": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.primitives": "10.0.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.configuration.abstractions": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.primitives": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.dependencyinjection": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.diagnostics.abstractions": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.options": "10.0.3",
+        "org.nuget.system.diagnostics.diagnosticsource": "10.0.3",
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.memory": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.features": {
+      "version": "10.0.3",
+      "depth": 4,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.fileproviders.abstractions": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.primitives": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.hosting.abstractions": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.microsoft.extensions.configuration.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.diagnostics.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.fileproviders.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.logging.abstractions": "10.0.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.logging": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.microsoft.extensions.dependencyinjection": "10.0.3",
+        "org.nuget.microsoft.extensions.logging.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.options": "10.0.3",
+        "org.nuget.system.diagnostics.diagnosticsource": "10.0.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.logging.abstractions": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.system.diagnostics.diagnosticsource": "10.0.3",
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.memory": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.options": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.3",
+        "org.nuget.microsoft.extensions.primitives": "10.0.3",
+        "org.nuget.system.componentmodel.annotations": "5.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.microsoft.extensions.primitives": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.r3": {
+      "version": "1.3.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.timeprovider": "8.0.0",
+        "org.nuget.system.buffers": "4.5.1",
+        "org.nuget.system.componentmodel.annotations": "5.0.0",
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0",
+        "org.nuget.system.threading.channels": "8.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.buffers": {
+      "version": "4.6.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.collections.immutable": {
+      "version": "9.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.componentmodel.annotations": {
+      "version": "5.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.diagnostics.diagnosticsource": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.io.pipelines": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.memory": {
+      "version": "4.6.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.numerics.vectors": "4.6.1",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.net.serversentevents": {
+      "version": "10.0.3",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.numerics.vectors": {
+      "version": "4.6.1",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.reflection.metadata": {
+      "version": "9.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.collections.immutable": "9.0.0",
+        "org.nuget.system.memory": "4.5.5"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.runtime.compilerservices.unsafe": {
+      "version": "6.1.2",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.text.encoding.codepages": {
+      "version": "7.0.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.memory": "4.5.5",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.0.0"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.text.encodings.web": {
+      "version": "10.0.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.text.json": {
+      "version": "10.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.system.io.pipelines": "10.0.3",
+        "org.nuget.system.text.encodings.web": "10.0.3",
+        "org.nuget.system.buffers": "4.6.1",
+        "org.nuget.system.memory": "4.6.3",
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.threading.channels": {
+      "version": "10.0.3",
+      "depth": 3,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.microsoft.bcl.asyncinterfaces": "10.0.3",
+        "org.nuget.system.threading.tasks.extensions": "4.6.3"
+      },
+      "url": "https://package.openupm.com"
+    },
+    "org.nuget.system.threading.tasks.extensions": {
+      "version": "4.6.3",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "org.nuget.system.runtime.compilerservices.unsafe": "6.1.2"
+      },
+      "url": "https://package.openupm.com"
     },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -11,6 +11,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/SampleScene.unity
     guid: 8c9cfa26abfee488c85f1582747f6a02
+  - enabled: 1
+    path: Assets/Scenes/Level 2.unity
+    guid: 32ea153e1aef4d041a4dac730adfbe36
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -27,11 +27,24 @@ MonoBehaviour:
     m_IsDefault: 1
     m_Capabilities: 7
     m_ConfigSource: 0
-  m_UserSelectedRegistryName: 
+  - m_Id: scoped:project:package.openupm.com
+    m_Name: package.openupm.com
+    m_Url: https://package.openupm.com
+    m_Scopes:
+    - com.ivanmurzak
+    - extensions.unity
+    - org.nuget.com.ivanmurzak
+    - org.nuget.microsoft
+    - org.nuget.system
+    - org.nuget.r3
+    m_IsDefault: 0
+    m_Capabilities: 0
+    m_ConfigSource: 4
+  m_UserSelectedRegistryName: package.openupm.com
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -896
-    m_OriginalInstanceId: -898
+    m_UserModificationsInstanceId: -878
+    m_OriginalInstanceId: -880
   m_LoadAssets: 0

--- a/args.json
+++ b/args.json
@@ -1,0 +1,1 @@
+{"path": "Assets/Scenes/BossLevel.unity"}


### PR DESCRIPTION
Add a large set of Unity MCP skill documentation files under .claude and .gemini (animation, animator, assets, editor, gameobject, package, scene, scripting, tools, tests, screenshots, reflection, etc.), plus local and global MCP settings (.claude/settings.local.json, .gemini/settings.json, .mcp.json, args.json). Add a new BossLevel scene and related scripts (BossArenaTrigger, BossDefeatedTrigger, GameVictoryManager, LevelManager) with their .meta files, and update SampleScene.unity and project settings (EditorBuildSettings.asset, PackageManagerSettings.asset) and Packages/manifest.json to integrate the new content.